### PR TITLE
Migrate docs sync and harden daily publishing

### DIFF
--- a/.github/PREVIEW_DISPATCH.md
+++ b/.github/PREVIEW_DISPATCH.md
@@ -1,0 +1,58 @@
+# Documentation preview dispatch
+
+Documentation remains canonical in `docs/cli`. Three workflows support the
+website integration:
+
+- `docs-validate.yml` checks `SUMMARY.md`, page coverage, headings, and local
+  links for every pull request and `main` update.
+- `docs-preview-dispatch.yml` sends the exact documentation commit and source
+  repository to the secret-free site build in `Margin-Lab/marginlab`.
+- `docs-release-dispatch.yml` emits the distinct `docs-release` event only for
+  a trusted `Margin-Lab/evals` `main` revision. Pull-request documentation can
+  never enter this production-eligible path.
+
+The preview dispatch workflow uses `pull_request_target`, checks out the exact
+frozen base-branch revision from the event, and never reads or executes
+pull-request content. Preview
+dispatch is limited to non-draft branches in `Margin-Lab/evals`; fork pull
+requests still receive secret-free documentation validation but cannot consume
+the deployment credential or publish arbitrary content to the preview domain.
+
+The release workflow is separate and runs only after documentation reaches
+`main`. It has no manual trigger because it handles a GitHub App credential.
+Its payload includes both `source_ref: refs/heads/main` and a `source_sha`
+matching the requested documentation SHA. The website repository independently
+resolves and verifies `Margin-Lab/evals` `main` before it labels a build as
+production eligible.
+
+## Required GitHub App
+
+Create a dedicated GitHub App for preview dispatches and install it only on
+`Margin-Lab/marginlab`.
+
+- Repository permission: **Contents — Read and write**
+- Repository selection: **Only select repositories → `marginlab`**
+- No organization, administration, pull-request, Actions, or deployment
+  permissions are required.
+
+GitHub's repository-dispatch endpoint requires Contents write permission. The
+App token does not receive Firebase credentials and cannot deploy a site
+directly. The trusted workflow uses its broader Contents permission only to
+send the repository-dispatch event, so the private key must remain protected.
+
+Configure these values in `Margin-Lab/evals`:
+
+| Kind | Name |
+| --- | --- |
+| Repository variable | `MARGINLAB_PREVIEW_APP_ID` |
+| Repository secret | `MARGINLAB_PREVIEW_APP_PRIVATE_KEY` |
+
+The workflows exchange the private key for a short-lived installation token
+and send only the exact docs SHA, canonical dispatcher, docs source repository,
+release intent, docs PR number when applicable, and preview channel ID. The
+later privileged Firebase workflow consumes the successful static artifact
+without executing it. Do not replace this with a broadly scoped personal
+access token.
+
+The receiving workflow and the rest of the required configuration are
+documented in `Margin-Lab/marginlab/.github/PREVIEW_AUTOMATION.md`.

--- a/.github/scripts/dispatch-docs-site.mjs
+++ b/.github/scripts/dispatch-docs-site.mjs
@@ -1,0 +1,119 @@
+const token = requireEnvironment('MARGINLAB_PREVIEW_TOKEN');
+const docsSha = requireSha('DOCS_SHA');
+const dispatchEvent = requireDispatchEvent('DISPATCH_EVENT');
+const sourceRepository =
+  process.env.SOURCE_REPOSITORY ?? 'Margin-Lab/evals';
+const docsRepository =
+  process.env.DOCS_REPOSITORY ?? sourceRepository;
+const targetRepository =
+  process.env.TARGET_REPOSITORY ?? 'Margin-Lab/marginlab';
+const previewId = normalizePreviewId(
+  process.env.PREVIEW_ID ?? `docs-${docsSha.slice(0, 12)}`,
+);
+const sourceRef = process.env.SOURCE_REF || null;
+const sourceSha = process.env.SOURCE_SHA?.toLowerCase() || null;
+
+if (sourceRepository !== 'Margin-Lab/evals') {
+  throw new Error(`Unexpected source repository: ${sourceRepository}`);
+}
+if (targetRepository !== 'Margin-Lab/marginlab') {
+  throw new Error(`Unexpected target repository: ${targetRepository}`);
+}
+if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(docsRepository)) {
+  throw new Error(`Invalid documentation repository: ${docsRepository}`);
+}
+if (
+  dispatchEvent === 'docs-release'
+  && (
+    docsRepository !== 'Margin-Lab/evals'
+    || process.env.DOCS_PR
+    || previewId !== 'docs-main'
+    || sourceRef !== 'refs/heads/main'
+    || sourceSha !== docsSha
+  )
+) {
+  throw new Error(
+    'docs-release must target Margin-Lab/evals main without a pull request',
+  );
+}
+
+const response = await fetch(
+  `https://api.github.com/repos/${targetRepository}/dispatches`,
+  {
+    method: 'POST',
+    headers: {
+      Accept: 'application/vnd.github+json',
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      'User-Agent': 'marginlab-docs-site-dispatch',
+      'X-GitHub-Api-Version': '2022-11-28',
+    },
+    body: JSON.stringify({
+      event_type: dispatchEvent,
+      client_payload: {
+        source_repository: sourceRepository,
+        docs_repository: docsRepository,
+        docs_sha: docsSha,
+        preview_id: previewId,
+        docs_pr: process.env.DOCS_PR || null,
+        source_ref: sourceRef,
+        source_sha: sourceSha,
+      },
+    }),
+  },
+);
+
+if (!response.ok) {
+  const responseBody = await response.text();
+  throw new Error(
+    `GitHub repository dispatch failed (${response.status}): ${responseBody}`,
+  );
+}
+
+console.log(
+  `Requested MarginLab ${dispatchEvent} build ${previewId} for documentation ${docsSha}.`,
+);
+
+function requireEnvironment(name) {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`${name} is required`);
+  }
+  return value;
+}
+
+function requireSha(name) {
+  const value = requireEnvironment(name).toLowerCase();
+  if (!/^[0-9a-f]{40}$/.test(value)) {
+    throw new Error(`${name} must be a full 40-character Git commit SHA`);
+  }
+  return value;
+}
+
+function requireDispatchEvent(name) {
+  const value = requireEnvironment(name);
+  if (!['docs-preview', 'docs-release'].includes(value)) {
+    throw new Error(
+      `${name} must be either docs-preview or docs-release`,
+    );
+  }
+  return value;
+}
+
+function normalizePreviewId(value) {
+  const normalized = value
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .replace(/-+/g, '-')
+    .slice(0, 40)
+    .replace(/-+$/g, '');
+
+  if (!normalized) {
+    throw new Error('Preview ID is empty after normalization');
+  }
+  if (['live', 'main', 'prod', 'production'].includes(normalized)) {
+    throw new Error(`${normalized} is reserved and cannot identify a preview`);
+  }
+  return normalized;
+}

--- a/.github/scripts/dispatch-docs-site.test.mjs
+++ b/.github/scripts/dispatch-docs-site.test.mjs
@@ -1,0 +1,101 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+const docsSha = 'b68519d5194bf8dbc61e56201951f01c5c497817';
+const scriptUrl = new URL('./dispatch-docs-site.mjs', import.meta.url);
+
+test('docs-release carries an independently verifiable main-branch identity', async () => {
+  let request;
+  await runDispatch(
+    {
+      DISPATCH_EVENT: 'docs-release',
+      DOCS_SHA: docsSha,
+      PREVIEW_ID: 'docs-main',
+      SOURCE_REF: 'refs/heads/main',
+      SOURCE_SHA: docsSha,
+    },
+    (url, options) => {
+      request = { url, options };
+      return { ok: true };
+    },
+  );
+
+  assert.equal(
+    request.url,
+    'https://api.github.com/repos/Margin-Lab/marginlab/dispatches',
+  );
+  const payload = JSON.parse(request.options.body);
+  assert.deepEqual(payload, {
+    event_type: 'docs-release',
+    client_payload: {
+      source_repository: 'Margin-Lab/evals',
+      docs_repository: 'Margin-Lab/evals',
+      docs_sha: docsSha,
+      preview_id: 'docs-main',
+      docs_pr: null,
+      source_ref: 'refs/heads/main',
+      source_sha: docsSha,
+    },
+  });
+});
+
+test('docs-release rejects a non-main source identity before dispatch', async () => {
+  await assert.rejects(
+    runDispatch(
+      {
+        DISPATCH_EVENT: 'docs-release',
+        DOCS_SHA: docsSha,
+        PREVIEW_ID: 'docs-main',
+        SOURCE_REF: 'refs/heads/feature',
+        SOURCE_SHA: docsSha,
+      },
+      () => {
+        throw new Error('fetch must not run');
+      },
+    ),
+    /docs-release must target Margin-Lab\/evals main/,
+  );
+});
+
+async function runDispatch(overrides, fetchImplementation) {
+  const names = [
+    'MARGINLAB_PREVIEW_TOKEN',
+    'DISPATCH_EVENT',
+    'DOCS_SHA',
+    'DOCS_REPOSITORY',
+    'DOCS_PR',
+    'PREVIEW_ID',
+    'SOURCE_REF',
+    'SOURCE_REPOSITORY',
+    'SOURCE_SHA',
+    'TARGET_REPOSITORY',
+  ];
+  const previousEnvironment = Object.fromEntries(
+    names.map((name) => [name, process.env[name]]),
+  );
+  const previousFetch = globalThis.fetch;
+
+  for (const name of names) {
+    delete process.env[name];
+  }
+  Object.assign(process.env, {
+    MARGINLAB_PREVIEW_TOKEN: 'test-token',
+    ...overrides,
+  });
+  globalThis.fetch = async (url, options) =>
+    fetchImplementation(url, options);
+
+  try {
+    await import(`${scriptUrl.href}?test=${crypto.randomUUID()}`);
+  } finally {
+    globalThis.fetch = previousFetch;
+    for (const name of names) {
+      const value = previousEnvironment[name];
+      if (value === undefined) {
+        delete process.env[name];
+      } else {
+        process.env[name] = value;
+      }
+    }
+  }
+}

--- a/.github/scripts/validate-docs.mjs
+++ b/.github/scripts/validate-docs.mjs
@@ -1,0 +1,239 @@
+import { readdir, readFile, stat } from 'node:fs/promises';
+import path from 'node:path';
+
+const docsRoot = path.resolve(process.argv[2] ?? 'docs/cli');
+const summaryPath = path.join(docsRoot, 'SUMMARY.md');
+const failures = [];
+
+await assertDirectory(docsRoot);
+
+const summary = await readFile(summaryPath, 'utf8');
+const summaryEntries = parseSummary(summary);
+const summaryPaths = new Set();
+
+for (const entry of summaryEntries) {
+  const normalizedPath = normalizeSummaryPath(entry.target, entry.line);
+  if (!normalizedPath) {
+    continue;
+  }
+
+  if (summaryPaths.has(normalizedPath)) {
+    failures.push(
+      `SUMMARY.md:${entry.line}: duplicate navigation target ${normalizedPath}`,
+    );
+    continue;
+  }
+
+  summaryPaths.add(normalizedPath);
+  await assertFile(
+    path.join(docsRoot, normalizedPath),
+    `SUMMARY.md:${entry.line}: missing page ${normalizedPath}`,
+  );
+}
+
+const contentFiles = (await walkMarkdown(docsRoot))
+  .map((file) => path.relative(docsRoot, file).split(path.sep).join('/'))
+  .filter((file) => file !== 'SUMMARY.md')
+  .sort();
+
+for (const contentFile of contentFiles) {
+  if (!summaryPaths.has(contentFile)) {
+    failures.push(`Page is not listed in SUMMARY.md: ${contentFile}`);
+  }
+
+  await validatePage(path.join(docsRoot, contentFile), contentFile);
+}
+
+for (const summaryPage of summaryPaths) {
+  if (!contentFiles.includes(summaryPage)) {
+    failures.push(`SUMMARY.md contains a non-content page: ${summaryPage}`);
+  }
+}
+
+if (summaryEntries.length === 0) {
+  failures.push('SUMMARY.md does not contain any linked pages');
+}
+
+if (failures.length > 0) {
+  console.error('Documentation validation failed:');
+  for (const failure of failures) {
+    console.error(`  - ${failure}`);
+  }
+  process.exitCode = 1;
+} else {
+  console.log(
+    `Validated ${contentFiles.length} documentation pages and ${summaryEntries.length} navigation entries.`,
+  );
+}
+
+function parseSummary(markdown) {
+  const entries = [];
+  const lines = stripCodeFences(markdown).split(/\r?\n/);
+  const linkPattern = /^\s*[-*+]\s+\[([^\]]+)\]\(([^)]+)\)\s*$/;
+
+  for (const [index, line] of lines.entries()) {
+    const match = line.match(linkPattern);
+    if (match) {
+      entries.push({
+        label: match[1].trim(),
+        target: cleanLinkTarget(match[2]),
+        line: index + 1,
+      });
+    }
+  }
+
+  return entries;
+}
+
+function normalizeSummaryPath(target, line) {
+  const withoutFragment = target.split(/[?#]/, 1)[0];
+  let decoded;
+
+  try {
+    decoded = decodeURIComponent(withoutFragment);
+  } catch {
+    failures.push(`SUMMARY.md:${line}: malformed URL encoding in ${target}`);
+    return null;
+  }
+
+  if (
+    decoded === '' ||
+    path.isAbsolute(decoded) ||
+    decoded.includes('\\') ||
+    path.extname(decoded).toLowerCase() !== '.md'
+  ) {
+    failures.push(
+      `SUMMARY.md:${line}: target must be a relative Markdown file: ${target}`,
+    );
+    return null;
+  }
+
+  const normalized = path.posix.normalize(decoded);
+  if (normalized === '..' || normalized.startsWith('../')) {
+    failures.push(`SUMMARY.md:${line}: target escapes docs/cli: ${target}`);
+    return null;
+  }
+
+  return normalized;
+}
+
+async function validatePage(absolutePath, relativePath) {
+  const markdown = await readFile(absolutePath, 'utf8');
+  const contentWithoutCode = stripCodeFences(markdown);
+  const h1Lines = contentWithoutCode
+    .split(/\r?\n/)
+    .map((line, index) => ({ line, number: index + 1 }))
+    .filter(({ line }) => /^#\s+\S/.test(line));
+
+  if (h1Lines.length !== 1) {
+    failures.push(
+      `${relativePath}: expected exactly one level-one heading, found ${h1Lines.length}`,
+    );
+  }
+
+  const markdownLinks =
+    contentWithoutCode.matchAll(/!?\[[^\]]*\]\(([^)\n]+)\)/g);
+
+  for (const match of markdownLinks) {
+    const target = cleanLinkTarget(match[1]);
+    if (
+      target === '' ||
+      target.startsWith('#') ||
+      target.startsWith('/') ||
+      /^(?:https?:|mailto:|tel:|data:)/i.test(target)
+    ) {
+      continue;
+    }
+
+    const targetWithoutFragment = target.split(/[?#]/, 1)[0];
+    let decoded;
+    try {
+      decoded = decodeURIComponent(targetWithoutFragment);
+    } catch {
+      failures.push(`${relativePath}: malformed URL encoding in link ${target}`);
+      continue;
+    }
+
+    const resolvedPath = path.resolve(path.dirname(absolutePath), decoded);
+    if (
+      resolvedPath !== docsRoot &&
+      !resolvedPath.startsWith(`${docsRoot}${path.sep}`)
+    ) {
+      failures.push(`${relativePath}: local link escapes docs/cli: ${target}`);
+      continue;
+    }
+
+    await assertFile(
+      resolvedPath,
+      `${relativePath}: unresolved local link ${target}`,
+    );
+  }
+}
+
+function cleanLinkTarget(rawTarget) {
+  const trimmed = rawTarget.trim();
+  if (trimmed.startsWith('<') && trimmed.endsWith('>')) {
+    return trimmed.slice(1, -1);
+  }
+
+  // Markdown permits an optional quoted title after the URL. Documentation
+  // paths in this repository do not contain spaces, so this is unambiguous.
+  return trimmed.replace(/\s+(?:"[^"]*"|'[^']*')\s*$/, '');
+}
+
+function stripCodeFences(markdown) {
+  const lines = markdown.split(/\r?\n/);
+  let fence = null;
+
+  return lines
+    .map((line) => {
+      const marker = line.match(/^\s*(`{3,}|~{3,})/);
+      if (marker) {
+        if (fence === null) {
+          fence = marker[1][0];
+        } else if (marker[1][0] === fence) {
+          fence = null;
+        }
+        return '';
+      }
+      return fence === null ? line : '';
+    })
+    .join('\n');
+}
+
+async function walkMarkdown(directory) {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const files = await Promise.all(
+    entries.map((entry) => {
+      const absolutePath = path.join(directory, entry.name);
+      if (entry.isDirectory()) {
+        return walkMarkdown(absolutePath);
+      }
+      return entry.isFile() && entry.name.endsWith('.md') ? [absolutePath] : [];
+    }),
+  );
+  return files.flat();
+}
+
+async function assertDirectory(directory) {
+  try {
+    const metadata = await stat(directory);
+    if (!metadata.isDirectory()) {
+      throw new Error('not a directory');
+    }
+  } catch {
+    console.error(`Documentation root is unavailable: ${directory}`);
+    process.exit(1);
+  }
+}
+
+async function assertFile(file, failureMessage) {
+  try {
+    const metadata = await stat(file);
+    if (!metadata.isFile()) {
+      failures.push(failureMessage);
+    }
+  } catch {
+    failures.push(failureMessage);
+  }
+}

--- a/.github/workflows/daily-run-validate.yml
+++ b/.github/workflows/daily-run-validate.yml
@@ -1,0 +1,36 @@
+name: Daily runner validation
+
+on:
+  pull_request:
+    paths:
+      - ops/daily-runs/**
+      - .github/workflows/daily-run-validate.yml
+  push:
+    branches:
+      - main
+    paths:
+      - ops/daily-runs/**
+      - .github/workflows/daily-run-validate.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: daily-run-validation-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Test orchestration and statistics
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Run safe daily-run tests
+        run: ./ops/daily-runs/test.sh

--- a/.github/workflows/docs-preview-dispatch.yml
+++ b/.github/workflows/docs-preview-dispatch.yml
@@ -1,0 +1,92 @@
+name: Request website documentation preview
+
+# pull_request_target loads this workflow and its scripts from the trusted base
+# branch. It never checks out or executes pull-request-controlled content.
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+    paths:
+      - docs/cli/**
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docs-preview-dispatch-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  dispatch:
+    name: Request a secret-isolated preview build
+    if: >-
+      !github.event.pull_request.draft
+      && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out trusted dispatch code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
+
+      - name: Verify frozen dispatch policy checkout
+        shell: bash
+        env:
+          EXPECTED_POLICY_SHA: ${{ github.event.pull_request.base.sha }}
+        run: test "$(git rev-parse HEAD)" = "$EXPECTED_POLICY_SHA"
+
+      - name: Resolve requested documentation revision
+        id: docs
+        shell: bash
+        env:
+          REQUESTED_SHA: >-
+            ${{ github.event.pull_request.head.sha }}
+          REQUESTED_REPOSITORY: >-
+            ${{ github.event.pull_request.head.repo.full_name }}
+        run: |
+          set -euo pipefail
+
+          docs_sha="${REQUESTED_SHA,,}"
+          if [[ ! "$docs_sha" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::docs_sha must be an exact 40-character commit SHA"
+            exit 1
+          fi
+          if [[ ! "$REQUESTED_REPOSITORY" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
+            echo "::error::Invalid documentation repository"
+            exit 1
+          fi
+
+          echo "sha=$docs_sha" >> "$GITHUB_OUTPUT"
+          echo "repository=$REQUESTED_REPOSITORY" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22
+
+      - name: Create short-lived preview dispatch token
+        id: preview-token
+        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+        with:
+          app-id: ${{ vars.MARGINLAB_PREVIEW_APP_ID }}
+          private-key: ${{ secrets.MARGINLAB_PREVIEW_APP_PRIVATE_KEY }}
+          owner: Margin-Lab
+          repositories: marginlab
+
+      - name: Request secret-free build from website repository
+        env:
+          MARGINLAB_PREVIEW_TOKEN: ${{ steps.preview-token.outputs.token }}
+          DOCS_REPOSITORY: ${{ steps.docs.outputs.repository }}
+          DOCS_SHA: ${{ steps.docs.outputs.sha }}
+          DOCS_PR: ${{ github.event.pull_request.number }}
+          PREVIEW_ID: docs-pr-${{ github.event.pull_request.number }}
+          DISPATCH_EVENT: docs-preview
+          SOURCE_REPOSITORY: Margin-Lab/evals
+          TARGET_REPOSITORY: Margin-Lab/marginlab
+        run: node .github/scripts/dispatch-docs-site.mjs

--- a/.github/workflows/docs-release-dispatch.yml
+++ b/.github/workflows/docs-release-dispatch.yml
@@ -1,0 +1,79 @@
+name: Request website documentation release
+
+# A production-eligible documentation build is emitted only by a trusted push
+# to the canonical default branch. Pull requests use the separate
+# docs-preview event and can never enter this path.
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - docs/cli/**
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docs-release-dispatch
+  cancel-in-progress: true
+
+jobs:
+  dispatch:
+    name: Request a production-eligible documentation build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out the trusted documentation revision
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - name: Validate the release revision
+        id: docs
+        shell: bash
+        env:
+          REQUESTED_SHA: ${{ github.sha }}
+          REQUESTED_REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          docs_sha="${REQUESTED_SHA,,}"
+          if [[ "$REQUESTED_REPOSITORY" != "Margin-Lab/evals" ]]; then
+            echo "::error::Documentation releases require Margin-Lab/evals"
+            exit 1
+          fi
+          if [[ ! "$docs_sha" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::docs_sha must be an exact 40-character commit SHA"
+            exit 1
+          fi
+
+          echo "sha=$docs_sha" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22
+
+      - name: Create short-lived site dispatch token
+        id: site-token
+        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+        with:
+          app-id: ${{ vars.MARGINLAB_PREVIEW_APP_ID }}
+          private-key: ${{ secrets.MARGINLAB_PREVIEW_APP_PRIVATE_KEY }}
+          owner: Margin-Lab
+          repositories: marginlab
+
+      - name: Request the trusted release build
+        env:
+          MARGINLAB_PREVIEW_TOKEN: ${{ steps.site-token.outputs.token }}
+          DOCS_REPOSITORY: Margin-Lab/evals
+          DOCS_SHA: ${{ steps.docs.outputs.sha }}
+          PREVIEW_ID: docs-main
+          DISPATCH_EVENT: docs-release
+          SOURCE_REF: refs/heads/main
+          SOURCE_SHA: ${{ steps.docs.outputs.sha }}
+          SOURCE_REPOSITORY: Margin-Lab/evals
+          TARGET_REPOSITORY: Margin-Lab/marginlab
+        run: node .github/scripts/dispatch-docs-site.mjs

--- a/.github/workflows/docs-validate.yml
+++ b/.github/workflows/docs-validate.yml
@@ -1,0 +1,54 @@
+name: Documentation validation
+
+on:
+  pull_request:
+    paths:
+      - docs/cli/**
+      - .github/scripts/dispatch-docs-site.mjs
+      - .github/scripts/dispatch-docs-site.test.mjs
+      - .github/scripts/validate-docs.mjs
+      - .github/workflows/docs-preview-dispatch.yml
+      - .github/workflows/docs-release-dispatch.yml
+      - .github/workflows/docs-validate.yml
+  push:
+    branches:
+      - main
+    paths:
+      - docs/cli/**
+      - .github/scripts/dispatch-docs-site.mjs
+      - .github/scripts/dispatch-docs-site.test.mjs
+      - .github/scripts/validate-docs.mjs
+      - .github/workflows/docs-preview-dispatch.yml
+      - .github/workflows/docs-release-dispatch.yml
+      - .github/workflows/docs-validate.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docs-validation-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: Validate navigation and links
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out documentation
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22
+
+      - name: Validate documentation
+        run: node .github/scripts/validate-docs.mjs docs/cli
+
+      - name: Test documentation dispatch trust boundaries
+        run: node --test .github/scripts/dispatch-docs-site.test.mjs

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <p align="center">
   Open-source eval runtime for coding agents.
   <br /><br />
-  <a href="https://marginlab.ai">marginlab.ai</a> · <a href="https://docs.marginlab.ai">Documentation</a>
+  <a href="https://marginlab.ai">marginlab.ai</a> · <a href="https://marginlab.ai/docs/">Documentation</a>
   <br />
   <a href="https://x.com/themarginguy"><img src="https://img.shields.io/twitter/follow/themarginguy?style=social" alt="Follow on X"></a>
 </p>
@@ -151,7 +151,7 @@ Official SWE eval suites are hosted at `https://github.com/Margin-Lab/swe-suites
 
 Many more built-in evals coming soon.
 
-See Creating [Your Own Eval](https://docs.marginlab.ai/creating-your-own-eval/01-quickstart) for a guide on how to create your own eval suite.
+See Creating [Your Own Eval](https://marginlab.ai/docs/creating-your-own-eval/01-quickstart/) for a guide on how to create your own eval suite.
 
 ## Supported agents
 
@@ -165,7 +165,7 @@ See Creating [Your Own Eval](https://docs.marginlab.ai/creating-your-own-eval/01
 
 Agent configs support two modes: **direct** (full agent-specific control) and **unified** (one config format that works across all supported agents).
 
-Many more built-in agents coming soon. See [Adding a New Agent](https://docs.marginlab.ai/add-support-for-a-new-agent/01-overview) for a guide on how to add a new agent, and [Configuring Your Agent](https://docs.marginlab.ai/configuration/01-configuring-your-agent) for a guide on how to configure an existing agent.
+Many more built-in agents coming soon. See [Adding a New Agent](https://marginlab.ai/docs/add-support-for-a-new-agent/01-overview/) for a guide on how to add a new agent, and [Configuring Your Agent](https://marginlab.ai/docs/configuration/01-configuring-your-agent/) for a guide on how to configure an existing agent.
 
 ## Project structure
 
@@ -181,13 +181,13 @@ docs/                   Documentation
 
 ## Documentation
 
-- [What is Margin?](https://docs.marginlab.ai/welcome/01-what-is-margin)
-- [Installation](https://docs.marginlab.ai/quickstart/01-install)
-- [Running Your First Eval](https://docs.marginlab.ai/quickstart/02-running-your-first-eval)
-- [Configuring Your Agent](https://docs.marginlab.ai/configuration/01-configuring-your-agent)
-- [Configuring Your Eval](https://docs.marginlab.ai/configuration/02-configuring-your-eval)
-- [Creating Your Own Eval](https://docs.marginlab.ai/creating-your-own-eval/01-quickstart)
-- [Adding a New Agent](https://docs.marginlab.ai/add-support-for-a-new-agent/01-overview)
+- [What is Margin?](https://marginlab.ai/docs/welcome/01-what-is-margin/)
+- [Installation](https://marginlab.ai/docs/quickstart/01-install/)
+- [Running Your First Eval](https://marginlab.ai/docs/quickstart/02-running-your-first-eval/)
+- [Configuring Your Agent](https://marginlab.ai/docs/configuration/01-configuring-your-agent/)
+- [Configuring Your Eval](https://marginlab.ai/docs/configuration/02-configuring-your-eval/)
+- [Creating Your Own Eval](https://marginlab.ai/docs/creating-your-own-eval/01-quickstart/)
+- [Adding a New Agent](https://marginlab.ai/docs/add-support-for-a-new-agent/01-overview/)
 
 ## License
 

--- a/ops/daily-runs/.gitignore
+++ b/ops/daily-runs/.gitignore
@@ -1,0 +1,10 @@
+/agent-configs/
+/eval-config*.toml
+/logs/
+/runs/
+/warmup-claude.sh
+/statistics/__pycache__/
+*.py[cod]
+.env*
+*.key
+*.pem

--- a/ops/daily-runs/README.md
+++ b/ops/daily-runs/README.md
@@ -54,6 +54,39 @@ status totals, or too few policy-valid instances are excluded. The current
 run's `results.json` is explicitly required and must pass those checks, so a
 bad new run cannot be hidden by valid history or publish stale statistics.
 
+## Site-data publication
+
+The parent runner always invokes the website's site-data publisher after both
+trackers pass. With no flag, this is a read-only export and validation in a
+temporary directory. It does not fetch, commit, push, open a pull request, or
+deploy Firebase. The runner removes any inherited
+`MARGINLAB_SITE_DATA_PUBLISH` value in this mode.
+
+`./run.sh --publish` and `./run-from-cron.sh --publish` enable Git publication.
+The runner then supplies both confirmations required by the publisher:
+`--publish` and `MARGINLAB_SITE_DATA_PUBLISH=1`. After validating one immutable
+snapshot, the publisher stages only `site-data/**` in a temporary detached
+worktree, creates one descendant commit, and pushes that exact commit directly
+to `origin/main`. Immediately before the normal non-force push, it refetches
+and requires remote `main` to still equal the captured base; concurrent
+movement or a non-fast-forward update fails closed.
+
+The dedicated automation clone must be clean, on `main`, have canonical
+`Margin-Lab/marginlab` as its origin, and be explicitly marked:
+
+```sh
+git -C /home/jbouza/Projects/marginlab-site-data-automation \
+  config --local marginlab.siteDataAutomation true
+```
+
+A retry with an already-published payload is a deterministic no-op. The
+temporary worktree is removed even after failure, and the dedicated clone is
+returned clean on an ff-only synchronized `main`; no retry branch or local
+publication commit needs reconciliation. If that final ff-only restoration
+cannot reconcile, publication fails for operator review. Publication does not
+run Firebase itself; the push starts the website's normal `main` checks and
+staging workflow, while production deployment remains separately approved.
+
 Optional overrides are:
 
 | Variable | Default |
@@ -104,7 +137,7 @@ git -C /home/jbouza/Projects/marginlab-eval/evals merge \
 ```
 
 Then create a candidate crontab from the installed one. The replacement keeps
-the existing schedule and adds no `--deploy` flag, so the first scheduled run
+the existing schedule and adds no `--publish` flag, so the first scheduled run
 still performs a publication dry run:
 
 ```sh
@@ -131,10 +164,44 @@ crontab "${cron_backup}"
 ```
 
 After the first scheduled run, verify its dated log under
-`/home/jbouza/Projects/marginlab-eval/daily-runs/logs`, confirm the automation
-clone stayed clean on `main`, and confirm no GitHub PR was created. Only then,
-and only after production deployment checks are required on `main`, should a
-separate reviewed change add `--deploy` to the cron command.
+`/home/jbouza/Projects/marginlab-eval/daily-runs/logs`. Confirm that it reports
+a successful dry run, and that the automation clone stayed clean on `main`
+without creating or pushing a commit:
+
+```sh
+git -C /home/jbouza/Projects/marginlab-site-data-automation status --short
+git -C /home/jbouza/Projects/marginlab-site-data-automation branch --show-current
+git -C /home/jbouza/Projects/marginlab-site-data-automation \
+  config --local --get marginlab.siteDataAutomation
+git -C /home/jbouza/Projects/marginlab-site-data-automation \
+  remote get-url origin
+```
+
+Only after that dry run and a review confirming the site-data validation and
+website `main` checks are ready should a second atomic crontab edit enable
+direct Git publication:
+
+```sh
+publish_backup="$(mktemp /tmp/marginlab-crontab.pre-publish.XXXXXX)"
+publish_candidate="$(mktemp /tmp/marginlab-crontab.publish.XXXXXX)"
+dry_runner="env MARGINLAB_EVAL_WORKSPACE_ROOT=/home/jbouza/Projects/marginlab-eval /home/jbouza/Projects/marginlab-eval/evals/ops/daily-runs/run-from-cron.sh"
+publish_runner="${dry_runner} --publish"
+
+crontab -l >"${publish_backup}"
+test "$(grep -Fc "${dry_runner}" "${publish_backup}")" -eq 1
+sed "s|${dry_runner}$|${publish_runner}|" \
+  "${publish_backup}" >"${publish_candidate}"
+grep -F "${publish_runner}" "${publish_candidate}"
+diff -u "${publish_backup}" "${publish_candidate}"
+crontab "${publish_candidate}"
+```
+
+Keep `publish_backup` through the first publication. Roll back to validation
+only with `crontab "${publish_backup}"`. After the first publish-mode run,
+confirm the log reports either the exact publication commit or a deterministic
+no-op, the automation clone is clean on `main`, and `origin/main` contains that
+commit. Also confirm the website's normal `main` checks started; this runner
+does not approve or perform a production Firebase deployment.
 
 The old external scripts can remain as a rollback copy until the new runner
 has completed multiple scheduled dry runs. They are no longer the source of

--- a/ops/daily-runs/README.md
+++ b/ops/daily-runs/README.md
@@ -1,0 +1,141 @@
+# Daily tracker operations
+
+This directory is the version-controlled source for MarginLab's daily Codex and
+Claude Code tracker runner. It contains orchestration and statistics code only.
+Run outputs, logs, credentials, agent configurations, eval configurations,
+warm-up scripts, and caches remain local operational state and must not be
+committed.
+
+The currently installed cron job still executes the external copy at:
+
+```text
+/home/jbouza/Projects/marginlab-eval/daily-runs/run-from-cron.sh
+```
+
+Do not switch cron to this copy until the pull request containing this
+directory is merged and the production `Margin-Lab/evals` checkout has
+fast-forwarded to that merge.
+
+## Runtime layout
+
+The scripts deliberately separate versioned code from local state. When run
+from the repository, set `MARGINLAB_EVAL_WORKSPACE_ROOT` to the existing
+workspace:
+
+```sh
+export MARGINLAB_EVAL_WORKSPACE_ROOT=/home/jbouza/Projects/marginlab-eval
+```
+
+When the repository is installed at the documented production path
+`<workspace>/evals/ops/daily-runs`, the default is resolved consistently as
+three parent directories above the scripts. Other checkout layouts must set
+`MARGINLAB_EVAL_WORKSPACE_ROOT` explicitly.
+
+That makes the scripts use the existing untracked state under
+`$MARGINLAB_EVAL_WORKSPACE_ROOT/daily-runs`, including `runs/`,
+`agent-configs/`, `eval-config*.toml`, and `warmup-claude.sh`.
+
+Retries are resumable at the sync boundary. If exactly one completed
+`results.json` and `statistics.json` pair already exists for a tracker and
+target date, the runner skips the paid evaluation, reruns that tracker's raw
+data sync, and lets the parent runner continue to publication. More than one
+completed run for the date fails closed for operator reconciliation.
+
+“Completed” is validated from content, not file presence: `results.state` must
+be `completed`, the suite size must match, and the statistics target date and
+failure policy must match the current invocation. Failed, stale, or legacy
+pairs are not reused. The versioned `sync-run.sh` copies the selected pair
+directly from `MARGINLAB_DAILY_STATE_DIR` to `MARGINLAB_RAW_REPOSITORY`, so
+location overrides apply through the entire retry path.
+
+Statistics generation applies the same sample contract before aggregation.
+Failed runs and prior completed runs with the wrong suite size, inconsistent
+status totals, or too few policy-valid instances are excluded. The current
+run's `results.json` is explicitly required and must pass those checks, so a
+bad new run cannot be hidden by valid history or publish stale statistics.
+
+Optional overrides are:
+
+| Variable | Default |
+| --- | --- |
+| `MARGINLAB_DAILY_STATE_DIR` | `$MARGINLAB_EVAL_WORKSPACE_ROOT/daily-runs` |
+| `MARGINLAB_SWE_SUITES_ROOT` | `$MARGINLAB_EVAL_WORKSPACE_ROOT/swe-suites` |
+| `MARGINLAB_PROJECTS_ROOT` | Parent of the eval workspace |
+| `MARGINLAB_RAW_REPOSITORY` | `$MARGINLAB_PROJECTS_ROOT/marginlab` |
+| `MARGINLAB_EVALUATION_ROOT` | `$MARGINLAB_EVAL_WORKSPACE_ROOT/evals` |
+| `MARGINLAB_AUTOMATION_ROOT` | `$MARGINLAB_PROJECTS_ROOT/marginlab-site-data-automation` |
+| `MARGINLAB_DAILY_LOG_DIR` | `$MARGINLAB_DAILY_STATE_DIR/logs` |
+| `MARGINLAB_DAILY_LOCK_FILE` | `/tmp/marginlab-daily-runs.lock` |
+| `MARGINLAB_DAILY_TIMEOUT_SECONDS` | `28800` |
+| `MARGINLAB_DAILY_ALERT_HOOK` | Empty; no hook |
+| `MARGINLAB_EXPECTED_INSTANCES` | `50` |
+| `MARGINLAB_MINIMUM_VALID_INSTANCES` | Expected instance count |
+| `MARGINLAB_NON_TEST_FAILURE_POLICY` | `exclude` |
+
+The alert hook, when configured, must be an executable absolute path. It
+receives `daily-run-failed`, the exit status, and the absolute log path.
+
+## Verify
+
+This command performs syntax and unit checks only; it does not run an
+evaluation, publish data, or deploy the site:
+
+```sh
+./ops/daily-runs/test.sh
+```
+
+Before activation, also confirm the production checkout is clean and points at
+the merged commit:
+
+```sh
+git -C /home/jbouza/Projects/marginlab-eval/evals status --short
+git -C /home/jbouza/Projects/marginlab-eval/evals log -1 --oneline
+```
+
+## Atomic activation after merge
+
+First fast-forward the production checkout and run the safe checks:
+
+```sh
+git -C /home/jbouza/Projects/marginlab-eval/evals fetch origin main
+git -C /home/jbouza/Projects/marginlab-eval/evals merge \
+  --ff-only origin/main
+/home/jbouza/Projects/marginlab-eval/evals/ops/daily-runs/test.sh
+```
+
+Then create a candidate crontab from the installed one. The replacement keeps
+the existing schedule and adds no `--deploy` flag, so the first scheduled run
+still performs a publication dry run:
+
+```sh
+cron_backup="$(mktemp /tmp/marginlab-crontab.backup.XXXXXX)"
+cron_candidate="$(mktemp /tmp/marginlab-crontab.candidate.XXXXXX)"
+old_runner="/home/jbouza/Projects/marginlab-eval/daily-runs/run-from-cron.sh"
+new_runner="env MARGINLAB_EVAL_WORKSPACE_ROOT=/home/jbouza/Projects/marginlab-eval /home/jbouza/Projects/marginlab-eval/evals/ops/daily-runs/run-from-cron.sh"
+
+crontab -l >"${cron_backup}"
+test "$(grep -Fc "${old_runner}" "${cron_backup}")" -eq 1
+sed "s|${old_runner}|${new_runner}|" \
+  "${cron_backup}" >"${cron_candidate}"
+grep -F "${new_runner}" "${cron_candidate}"
+diff -u "${cron_backup}" "${cron_candidate}"
+crontab "${cron_candidate}"
+```
+
+`crontab <file>` installs the complete candidate in one operation, avoiding a
+partially edited schedule. Keep `cron_backup` until the first scheduled dry run
+has succeeded. Roll back atomically with:
+
+```sh
+crontab "${cron_backup}"
+```
+
+After the first scheduled run, verify its dated log under
+`/home/jbouza/Projects/marginlab-eval/daily-runs/logs`, confirm the automation
+clone stayed clean on `main`, and confirm no GitHub PR was created. Only then,
+and only after production deployment checks are required on `main`, should a
+separate reviewed change add `--deploy` to the cron command.
+
+The old external scripts can remain as a rollback copy until the new runner
+has completed multiple scheduled dry runs. They are no longer the source of
+truth after activation.

--- a/ops/daily-runs/lib/paths.sh
+++ b/ops/daily-runs/lib/paths.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+marginlab_eval_workspace_root() {
+  local script_dir="$1"
+  local configured_root="${MARGINLAB_EVAL_WORKSPACE_ROOT:-}"
+  if [ -n "${configured_root}" ]; then
+    (cd "${configured_root}" && pwd)
+  else
+    # Production layout:
+    #   <workspace>/evals/ops/daily-runs
+    (cd "${script_dir}/../../.." && pwd)
+  fi
+}

--- a/ops/daily-runs/run-claude-code.sh
+++ b/ops/daily-runs/run-claude-code.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/lib/paths.sh"
+ROOT_DIR="$(marginlab_eval_workspace_root "${SCRIPT_DIR}")"
+DAILY_STATE_DIR="${MARGINLAB_DAILY_STATE_DIR:-${ROOT_DIR}/daily-runs}"
+SWE_SUITES_ROOT="${MARGINLAB_SWE_SUITES_ROOT:-${ROOT_DIR}/swe-suites}"
+PROJECTS_ROOT="${MARGINLAB_PROJECTS_ROOT:-$(cd "${ROOT_DIR}/.." && pwd)}"
+RAW_REPOSITORY="${MARGINLAB_RAW_REPOSITORY:-${PROJECTS_ROOT}/marginlab}"
+RUN_TIMESTAMP="${RUN_TIMESTAMP:-$(date +%Y%m%d-%H%M%S)}"
+TARGET_DIR="${DAILY_STATE_DIR}/runs/claude-code/${RUN_TIMESTAMP}"
+RUNS_DIR="$(dirname "${TARGET_DIR}")"
+RUN_DATE="${TARGET_DIR##*/}"
+RUN_DATE_FORMATTED="${RUN_DATE:0:4}-${RUN_DATE:4:2}-${RUN_DATE:6:2}"
+NON_TEST_FAILURE_POLICY="${MARGINLAB_NON_TEST_FAILURE_POLICY:-exclude}"
+EXPECTED_INSTANCES="${MARGINLAB_EXPECTED_INSTANCES:-50}"
+MINIMUM_VALID_INSTANCES="${MARGINLAB_MINIMUM_VALID_INSTANCES:-${EXPECTED_INSTANCES}}"
+SYNC_DESTINATION="${RAW_REPOSITORY}/data/benchmarks/degradation_trackers/claude_code/swe-bench-pro/data"
+
+validate_reusable_run() {
+  local run_root="$1"
+  python3 "${SCRIPT_DIR}/statistics/validate_reusable_run.py" \
+    --results "${run_root}/results.json" \
+    --statistics "${run_root}/statistics.json" \
+    --target-date "${RUN_DATE_FORMATTED}" \
+    --expected-instances "${EXPECTED_INSTANCES}" \
+    --minimum-valid-instances "${MINIMUM_VALID_INSTANCES}" \
+    --policy "${NON_TEST_FAILURE_POLICY}"
+}
+
+sync_run() {
+  "${SCRIPT_DIR}/sync-run.sh" \
+    --source-run "$1" \
+    --destination-root "${SYNC_DESTINATION}"
+}
+
+# Keep the daily tracker at one completed sample per date. Set FORCE_RUN=1
+# only for an intentional rerun that an operator will reconcile before publish.
+if [ "${FORCE_RUN:-0}" != "1" ]; then
+  completed_runs=()
+  for existing_run in "${RUNS_DIR}/${RUN_DATE:0:8}-"*; do
+    if [ -f "${existing_run}/results.json" ] && [ -f "${existing_run}/statistics.json" ]; then
+      if validate_reusable_run "${existing_run}"; then
+        completed_runs+=("${existing_run}")
+      else
+        echo "Ignoring non-reusable paired Claude Code run: ${existing_run}" >&2
+      fi
+    fi
+  done
+  if ((${#completed_runs[@]} > 1)); then
+    echo "Multiple completed Claude Code runs exist for ${RUN_DATE_FORMATTED}; refusing ambiguous sync" >&2
+    exit 1
+  fi
+  if ((${#completed_runs[@]} == 1)); then
+    echo "Reusing completed Claude Code run for ${RUN_DATE_FORMATTED}: ${completed_runs[0]}"
+    sync_run "${completed_runs[0]}"
+    exit 0
+  fi
+fi
+
+bash "${DAILY_STATE_DIR}/warmup-claude.sh"
+
+if ! margin run --output "${TARGET_DIR}" --suite "${SWE_SUITES_ROOT}/swe-bench-pro-curated-50" --agent-config "${DAILY_STATE_DIR}/agent-configs/claude-code-opus-5.0-high" --eval "${DAILY_STATE_DIR}/eval-config.toml" --non-interactive; then
+  echo "margin run returned non-zero for Claude Code; continuing to stats + sync" >&2
+fi
+
+python3 "${SCRIPT_DIR}/statistics/compute_stats.py" \
+  --runs_dir "${RUNS_DIR}" \
+  --output "${TARGET_DIR}/statistics.json" \
+  --date "${RUN_DATE_FORMATTED}" \
+  --baseline 0.73 \
+  --non-test-failure-policy "${NON_TEST_FAILURE_POLICY}" \
+  --expected-instances "${EXPECTED_INSTANCES}" \
+  --minimum-valid-instances "${MINIMUM_VALID_INSTANCES}" \
+  --required-results "${TARGET_DIR}/results.json"
+
+validate_reusable_run "${TARGET_DIR}"
+sync_run "${TARGET_DIR}"

--- a/ops/daily-runs/run-codex.sh
+++ b/ops/daily-runs/run-codex.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/lib/paths.sh"
+ROOT_DIR="$(marginlab_eval_workspace_root "${SCRIPT_DIR}")"
+DAILY_STATE_DIR="${MARGINLAB_DAILY_STATE_DIR:-${ROOT_DIR}/daily-runs}"
+SWE_SUITES_ROOT="${MARGINLAB_SWE_SUITES_ROOT:-${ROOT_DIR}/swe-suites}"
+PROJECTS_ROOT="${MARGINLAB_PROJECTS_ROOT:-$(cd "${ROOT_DIR}/.." && pwd)}"
+RAW_REPOSITORY="${MARGINLAB_RAW_REPOSITORY:-${PROJECTS_ROOT}/marginlab}"
+MODEL_SERIES="gpt-5-6-sol-high"
+RUN_TIMESTAMP="${RUN_TIMESTAMP:-$(date +%Y%m%d-%H%M%S)}"
+CODEX_RUNS_DIR="${DAILY_STATE_DIR}/runs/codex"
+TARGET_DIR="${CODEX_RUNS_DIR}/${MODEL_SERIES}/${RUN_TIMESTAMP}"
+RUNS_DIR="$(dirname "${TARGET_DIR}")"
+RUN_DATE="${TARGET_DIR##*/}"
+RUN_DATE_FORMATTED="${RUN_DATE:0:4}-${RUN_DATE:4:2}-${RUN_DATE:6:2}"
+BASELINE_P0="${CODEX_BASELINE_P0:-0.8340}"
+NON_TEST_FAILURE_POLICY="${MARGINLAB_NON_TEST_FAILURE_POLICY:-exclude}"
+EXPECTED_INSTANCES="${MARGINLAB_EXPECTED_INSTANCES:-50}"
+MINIMUM_VALID_INSTANCES="${MARGINLAB_MINIMUM_VALID_INSTANCES:-${EXPECTED_INSTANCES}}"
+SYNC_DESTINATION="${RAW_REPOSITORY}/data/benchmarks/degradation_trackers/codex/swe-bench-pro/data"
+BASELINE_SERIES=(
+  "gpt-5-6-sol-high"
+  "gpt-5-6-sol-xhigh"
+)
+
+validate_reusable_run() {
+  local run_root="$1"
+  python3 "${SCRIPT_DIR}/statistics/validate_reusable_run.py" \
+    --results "${run_root}/results.json" \
+    --statistics "${run_root}/statistics.json" \
+    --target-date "${RUN_DATE_FORMATTED}" \
+    --expected-instances "${EXPECTED_INSTANCES}" \
+    --minimum-valid-instances "${MINIMUM_VALID_INSTANCES}" \
+    --policy "${NON_TEST_FAILURE_POLICY}"
+}
+
+sync_run() {
+  "${SCRIPT_DIR}/sync-run.sh" \
+    --source-run "$1" \
+    --destination-root "${SYNC_DESTINATION}"
+}
+
+# Keep the daily tracker at one completed sample per model series and date.
+# Set FORCE_RUN=1 only when an intentional same-day rerun is required.
+if [ "${FORCE_RUN:-0}" != "1" ]; then
+  completed_runs=()
+  for existing_run in "${RUNS_DIR}/${RUN_DATE:0:8}-"*; do
+    if [ -f "${existing_run}/results.json" ] && [ -f "${existing_run}/statistics.json" ]; then
+      if validate_reusable_run "${existing_run}"; then
+        completed_runs+=("${existing_run}")
+      else
+        echo "Ignoring non-reusable paired Codex run: ${existing_run}" >&2
+      fi
+    fi
+  done
+  if ((${#completed_runs[@]} > 1)); then
+    echo "Multiple completed Codex runs exist for ${RUN_DATE_FORMATTED}; refusing ambiguous sync" >&2
+    exit 1
+  fi
+  if ((${#completed_runs[@]} == 1)); then
+    echo "Reusing completed Codex run for ${RUN_DATE_FORMATTED}: ${completed_runs[0]}"
+    sync_run "${completed_runs[0]}"
+    exit 0
+  fi
+fi
+
+if ! env -u OPENAI_API_KEY margin run \
+  --output "${TARGET_DIR}" \
+  --suite "${SWE_SUITES_ROOT}/swe-bench-pro-curated-50" \
+  --agent-config "${DAILY_STATE_DIR}/agent-configs/codex-gpt-5.6-sol-high" \
+  --eval "${DAILY_STATE_DIR}/eval-config-codex.toml" \
+  --non-interactive; then
+  echo "margin run returned non-zero for Codex; continuing to stats + sync" >&2
+fi
+
+STATS_ARGS=(
+  --output "${TARGET_DIR}/statistics.json"
+  --baseline "${BASELINE_P0}"
+  --date "${RUN_DATE_FORMATTED}"
+  --non-test-failure-policy "${NON_TEST_FAILURE_POLICY}"
+  --expected-instances "${EXPECTED_INSTANCES}"
+  --minimum-valid-instances "${MINIMUM_VALID_INSTANCES}"
+  --required-results "${TARGET_DIR}/results.json"
+)
+for series in "${BASELINE_SERIES[@]}"; do
+  STATS_ARGS+=(--runs_dir "${CODEX_RUNS_DIR}/${series}")
+done
+
+python3 "${SCRIPT_DIR}/statistics/compute_stats.py" "${STATS_ARGS[@]}"
+
+validate_reusable_run "${TARGET_DIR}"
+sync_run "${TARGET_DIR}"

--- a/ops/daily-runs/run-from-cron.sh
+++ b/ops/daily-runs/run-from-cron.sh
@@ -10,16 +10,16 @@ LOG_FILE="${LOG_DIR}/run-$(date +%Y%m%d).log"
 ZSH_BIN="/usr/bin/zsh"
 TIMEOUT_SECONDS="${MARGINLAB_DAILY_TIMEOUT_SECONDS:-28800}"
 ALERT_HOOK="${MARGINLAB_DAILY_ALERT_HOOK:-}"
-DEPLOY=0
+PUBLISH=0
 
 usage() {
-  echo "Usage: $0 [--deploy]" >&2
+  echo "Usage: $0 [--publish]" >&2
 }
 
 while (($# > 0)); do
   case "$1" in
-    --deploy)
-      DEPLOY=1
+    --publish)
+      PUBLISH=1
       ;;
     -h|--help)
       usage
@@ -44,8 +44,8 @@ mkdir -p "${LOG_DIR}"
   echo "[$(date '+%Y-%m-%dT%H:%M:%S%z')] Starting daily run"
 
   run_command="cd \"${SCRIPT_DIR}\" && ./run.sh"
-  if ((DEPLOY)); then
-    run_command+=" --deploy"
+  if ((PUBLISH)); then
+    run_command+=" --publish"
   fi
 
   if timeout --signal=TERM --kill-after=300 "${TIMEOUT_SECONDS}" \

--- a/ops/daily-runs/run-from-cron.sh
+++ b/ops/daily-runs/run-from-cron.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/lib/paths.sh"
+EVAL_WORKSPACE_ROOT="$(marginlab_eval_workspace_root "${SCRIPT_DIR}")"
+DAILY_STATE_DIR="${MARGINLAB_DAILY_STATE_DIR:-${EVAL_WORKSPACE_ROOT}/daily-runs}"
+LOG_DIR="${MARGINLAB_DAILY_LOG_DIR:-${DAILY_STATE_DIR}/logs}"
+LOG_FILE="${LOG_DIR}/run-$(date +%Y%m%d).log"
+ZSH_BIN="/usr/bin/zsh"
+TIMEOUT_SECONDS="${MARGINLAB_DAILY_TIMEOUT_SECONDS:-28800}"
+ALERT_HOOK="${MARGINLAB_DAILY_ALERT_HOOK:-}"
+DEPLOY=0
+
+usage() {
+  echo "Usage: $0 [--deploy]" >&2
+}
+
+while (($# > 0)); do
+  case "$1" in
+    --deploy)
+      DEPLOY=1
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+if ! [[ "${TIMEOUT_SECONDS}" =~ ^[1-9][0-9]*$ ]]; then
+  echo "MARGINLAB_DAILY_TIMEOUT_SECONDS must be a positive integer" >&2
+  exit 2
+fi
+
+mkdir -p "${LOG_DIR}"
+
+{
+  echo "[$(date '+%Y-%m-%dT%H:%M:%S%z')] Starting daily run"
+
+  run_command="cd \"${SCRIPT_DIR}\" && ./run.sh"
+  if ((DEPLOY)); then
+    run_command+=" --deploy"
+  fi
+
+  if timeout --signal=TERM --kill-after=300 "${TIMEOUT_SECONDS}" \
+    "${ZSH_BIN}" -lic "${run_command}"; then
+    status=0
+  else
+    status=$?
+  fi
+
+  echo "[$(date '+%Y-%m-%dT%H:%M:%S%z')] Finished daily run with status ${status}"
+
+  if ((status != 0)) && [ -n "${ALERT_HOOK}" ]; then
+    if [ ! -x "${ALERT_HOOK}" ]; then
+      echo "Alert hook is not executable: ${ALERT_HOOK}" >&2
+    elif ! "${ALERT_HOOK}" "daily-run-failed" "${status}" "${LOG_FILE}"; then
+      echo "Alert hook failed; preserving daily-run status ${status}" >&2
+    fi
+  fi
+
+  exit "${status}"
+} >> "${LOG_FILE}" 2>&1

--- a/ops/daily-runs/run.sh
+++ b/ops/daily-runs/run.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/lib/paths.sh"
-DEPLOY=0
+PUBLISH=0
 EVAL_WORKSPACE_ROOT="$(marginlab_eval_workspace_root "${SCRIPT_DIR}")"
 DAILY_STATE_DIR="${MARGINLAB_DAILY_STATE_DIR:-${EVAL_WORKSPACE_ROOT}/daily-runs}"
 PROJECTS_ROOT="${MARGINLAB_PROJECTS_ROOT:-$(cd "${EVAL_WORKSPACE_ROOT}/.." && pwd)}"
@@ -16,13 +16,13 @@ MINIMUM_VALID_INSTANCES="${MARGINLAB_MINIMUM_VALID_INSTANCES:-${EXPECTED_INSTANC
 NON_TEST_FAILURE_POLICY="${MARGINLAB_NON_TEST_FAILURE_POLICY:-exclude}"
 
 usage() {
-  echo "Usage: $0 [--deploy]" >&2
+  echo "Usage: $0 [--publish]" >&2
 }
 
 while (($# > 0)); do
   case "$1" in
-    --deploy)
-      DEPLOY=1
+    --publish)
+      PUBLISH=1
       ;;
     -h|--help)
       usage
@@ -89,11 +89,12 @@ PUBLISH_ARGUMENTS=(
   --non-test-failure-policy "${NON_TEST_FAILURE_POLICY}"
 )
 
-if ((DEPLOY)); then
+if ((PUBLISH)); then
   MARGINLAB_SITE_DATA_PUBLISH=1 \
     npm --prefix "${AUTOMATION_ROOT}/hosting" run publish:site-data -- \
     --publish "${PUBLISH_ARGUMENTS[@]}"
 else
-  npm --prefix "${AUTOMATION_ROOT}/hosting" run publish:site-data -- \
+  env -u MARGINLAB_SITE_DATA_PUBLISH \
+    npm --prefix "${AUTOMATION_ROOT}/hosting" run publish:site-data -- \
     "${PUBLISH_ARGUMENTS[@]}"
 fi

--- a/ops/daily-runs/run.sh
+++ b/ops/daily-runs/run.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/lib/paths.sh"
+DEPLOY=0
+EVAL_WORKSPACE_ROOT="$(marginlab_eval_workspace_root "${SCRIPT_DIR}")"
+DAILY_STATE_DIR="${MARGINLAB_DAILY_STATE_DIR:-${EVAL_WORKSPACE_ROOT}/daily-runs}"
+PROJECTS_ROOT="${MARGINLAB_PROJECTS_ROOT:-$(cd "${EVAL_WORKSPACE_ROOT}/.." && pwd)}"
+LOCK_FILE="${MARGINLAB_DAILY_LOCK_FILE:-/tmp/marginlab-daily-runs.lock}"
+AUTOMATION_ROOT="${MARGINLAB_AUTOMATION_ROOT:-${PROJECTS_ROOT}/marginlab-site-data-automation}"
+RAW_REPOSITORY="${MARGINLAB_RAW_REPOSITORY:-${PROJECTS_ROOT}/marginlab}"
+EVALUATION_ROOT="${MARGINLAB_EVALUATION_ROOT:-${EVAL_WORKSPACE_ROOT}/evals}"
+EXPECTED_INSTANCES="${MARGINLAB_EXPECTED_INSTANCES:-50}"
+MINIMUM_VALID_INSTANCES="${MARGINLAB_MINIMUM_VALID_INSTANCES:-${EXPECTED_INSTANCES}}"
+NON_TEST_FAILURE_POLICY="${MARGINLAB_NON_TEST_FAILURE_POLICY:-exclude}"
+
+usage() {
+  echo "Usage: $0 [--deploy]" >&2
+}
+
+while (($# > 0)); do
+  case "$1" in
+    --deploy)
+      DEPLOY=1
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+if ! [[ "${EXPECTED_INSTANCES}" =~ ^[1-9][0-9]*$ ]]; then
+  echo "MARGINLAB_EXPECTED_INSTANCES must be a positive integer" >&2
+  exit 2
+fi
+if ! [[ "${MINIMUM_VALID_INSTANCES}" =~ ^[1-9][0-9]*$ ]] \
+  || ((MINIMUM_VALID_INSTANCES > EXPECTED_INSTANCES)); then
+  echo "MARGINLAB_MINIMUM_VALID_INSTANCES must be positive and no greater than MARGINLAB_EXPECTED_INSTANCES" >&2
+  exit 2
+fi
+case "${NON_TEST_FAILURE_POLICY}" in
+  reject|count-as-failure|exclude)
+    ;;
+  *)
+    echo "MARGINLAB_NON_TEST_FAILURE_POLICY must be reject, count-as-failure, or exclude" >&2
+    exit 2
+    ;;
+esac
+
+exec 9>"${LOCK_FILE}"
+if ! flock -n 9; then
+  echo "Another daily run holds ${LOCK_FILE}; refusing to overlap" >&2
+  exit 75
+fi
+
+RUN_TIMESTAMP="${MARGINLAB_DAILY_RUN_TIMESTAMP:-$(date -u +%Y%m%d-%H%M%S)}"
+TARGET_DATE="${RUN_TIMESTAMP:0:4}-${RUN_TIMESTAMP:4:2}-${RUN_TIMESTAMP:6:2}"
+PUBLICATION_RUN_ID="daily-${TARGET_DATE}"
+export RUN_TIMESTAMP
+export MARGINLAB_EXPECTED_INSTANCES="${EXPECTED_INSTANCES}"
+export MARGINLAB_MINIMUM_VALID_INSTANCES="${MINIMUM_VALID_INSTANCES}"
+export MARGINLAB_NON_TEST_FAILURE_POLICY="${NON_TEST_FAILURE_POLICY}"
+export MARGINLAB_EVAL_WORKSPACE_ROOT="${EVAL_WORKSPACE_ROOT}"
+export MARGINLAB_DAILY_STATE_DIR="${DAILY_STATE_DIR}"
+export MARGINLAB_RAW_REPOSITORY="${RAW_REPOSITORY}"
+
+bash "${SCRIPT_DIR}/run-codex.sh"
+bash "${SCRIPT_DIR}/run-claude-code.sh"
+
+SOURCE_COMMIT="$(git -C "${RAW_REPOSITORY}" rev-parse HEAD)"
+EVALUATION_COMMIT="$(git -C "${EVALUATION_ROOT}" rev-parse HEAD)"
+PUBLISH_ARGUMENTS=(
+  --automation-root "${AUTOMATION_ROOT}"
+  --source "${RAW_REPOSITORY}/data"
+  --source-commit "${SOURCE_COMMIT}"
+  --evaluation-root "${EVALUATION_ROOT}"
+  --evaluation-commit "${EVALUATION_COMMIT}"
+  --run-id "${PUBLICATION_RUN_ID}"
+  --target-date "${TARGET_DATE}"
+  --expected-instances "${EXPECTED_INSTANCES}"
+  --minimum-valid-instances "${MINIMUM_VALID_INSTANCES}"
+  --non-test-failure-policy "${NON_TEST_FAILURE_POLICY}"
+)
+
+if ((DEPLOY)); then
+  MARGINLAB_SITE_DATA_PUBLISH=1 \
+    npm --prefix "${AUTOMATION_ROOT}/hosting" run publish:site-data -- \
+    --publish "${PUBLISH_ARGUMENTS[@]}"
+else
+  npm --prefix "${AUTOMATION_ROOT}/hosting" run publish:site-data -- \
+    "${PUBLISH_ARGUMENTS[@]}"
+fi

--- a/ops/daily-runs/statistics/compute_stats.py
+++ b/ops/daily-runs/statistics/compute_stats.py
@@ -1,0 +1,726 @@
+#!/usr/bin/env python3
+"""Compute statistical summaries for margin daily runs from native results.json files."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+from dataclasses import dataclass, field
+from datetime import UTC, date, datetime
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+
+TIMESCALES = {
+    "daily": 1,
+    "weekly": 7,
+    "monthly": 30,
+}
+
+BASELINE_P0 = 0.56
+NON_TEST_FAILURE_POLICIES = ("reject", "count-as-failure", "exclude")
+
+
+class NonCompletedRunError(ValueError):
+    """A structurally identified run that did not complete."""
+
+
+class NonReusableRunError(ValueError):
+    """A structurally valid completed run that is unsafe to aggregate."""
+
+
+@dataclass
+class BenchmarkRun:
+    run_id: str
+    timestamp: str
+    run_date: date
+    total: int
+    passed: int
+    status: Dict
+    runtime_ms: Optional[int]
+    input_tokens: int
+    output_tokens: int
+    tool_calls: int
+    cost_usd: Optional[float]
+    run_dir: Path
+
+    @property
+    def accuracy(self) -> float:
+        return self.passed / self.total if self.total > 0 else 0.0
+
+
+@dataclass
+class DayStats:
+    run_date: date
+    total_trials: int = 0
+    total_successes: int = 0
+    runs: List[BenchmarkRun] = field(default_factory=list)
+
+    @property
+    def accuracy(self) -> float:
+        return self.total_successes / self.total_trials if self.total_trials > 0 else 0.0
+
+
+@dataclass
+class WindowStats:
+    window_size: int
+    successes: int
+    trials: int
+    accuracy: float
+    delta: float
+    ci_lower: float
+    ci_upper: float
+    p_value_degradation: float
+    p_value_improvement: float
+    significance_threshold: float
+
+
+def _ensure_int(value: object, field_name: str) -> int:
+    if isinstance(value, bool):
+        raise ValueError(f"{field_name} must be a number, got boolean")
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        if not value.is_integer():
+            raise ValueError(f"{field_name} must be an integer, got non-integral float {value}")
+        return int(value)
+    raise ValueError(f"{field_name} must be an integer, got {type(value).__name__}")
+
+
+def _ensure_nonnegative_int(value: object, field_name: str) -> int:
+    parsed = _ensure_int(value, field_name)
+    if parsed < 0:
+        raise ValueError(f"{field_name} must be non-negative, got {parsed}")
+    return parsed
+
+
+def _ensure_float_or_none(value: object, field_name: str) -> Optional[float]:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        raise ValueError(f"{field_name} must be a number or null, got boolean")
+    if isinstance(value, (int, float)):
+        return float(value)
+    raise ValueError(f"{field_name} must be a number or null, got {type(value).__name__}")
+
+
+def _parse_run_timestamp(run_dir_name: str) -> Tuple[str, date]:
+    match = re.search(r"(\d{8}-\d{6})", run_dir_name or "")
+    if match:
+        timestamp = match.group(1)
+        run_date = datetime.strptime(timestamp[:8], "%Y%m%d").date()
+        return timestamp, run_date
+    raise ValueError(f"run directory {run_dir_name!r} is missing a timestamp pattern YYYYMMDD-HHMMSS")
+
+
+def load_benchmark_run(
+    results_json: Path,
+    *,
+    non_test_failure_policy: str,
+    expected_instances: int,
+    minimum_valid_instances: int,
+) -> BenchmarkRun:
+    if non_test_failure_policy not in NON_TEST_FAILURE_POLICIES:
+        raise ValueError(
+            "non_test_failure_policy must be one of "
+            + ", ".join(NON_TEST_FAILURE_POLICIES)
+        )
+    if expected_instances <= 0:
+        raise ValueError("expected_instances must be positive")
+    if (
+        minimum_valid_instances <= 0
+        or minimum_valid_instances > expected_instances
+    ):
+        raise ValueError(
+            "minimum_valid_instances must be positive and no greater than "
+            "expected_instances"
+        )
+    try:
+        with open(results_json) as f:
+            results = json.load(f)
+    except (json.JSONDecodeError, OSError):
+        raise ValueError(f"Failed to load JSON from {results_json}")
+    if not isinstance(results, dict):
+        raise ValueError(f"results.json must be an object in {results_json}")
+
+    state = results.get("state")
+    if not isinstance(state, str):
+        raise ValueError("missing required string field state")
+    if state != "completed":
+        raise NonCompletedRunError(f"run state is {state!r}, not 'completed'")
+
+    if "total_instances" not in results:
+        raise ValueError("missing required field total_instances")
+    total_instances = _ensure_nonnegative_int(
+        results.get("total_instances"),
+        "total_instances",
+    )
+
+    run_id = results.get("run_id")
+    if run_id is None:
+        raise ValueError("missing required field run_id")
+    run_id_str = str(run_id)
+    timestamp, run_date = _parse_run_timestamp(results_json.parent.name)
+
+    status = results.get("status")
+    if not isinstance(status, dict):
+        raise ValueError("missing required object status")
+
+    succeeded = status.get("succeeded")
+    if not isinstance(succeeded, dict) or "count" not in succeeded:
+        raise ValueError("missing required field status.succeeded.count")
+    passed = _ensure_nonnegative_int(
+        succeeded.get("count"),
+        "status.succeeded.count",
+    )
+
+    test_failed = status.get("test_failed")
+    if not isinstance(test_failed, dict) or "count" not in test_failed:
+        raise ValueError("missing required field status.test_failed.count")
+    failed_tests = _ensure_nonnegative_int(
+        test_failed.get("count"),
+        "status.test_failed.count",
+    )
+
+    infra_failed = status.get("infra_failed")
+    if not isinstance(infra_failed, dict) or "count" not in infra_failed:
+        raise ValueError("missing required field status.infra_failed.count")
+    failed_infra = _ensure_nonnegative_int(
+        infra_failed.get("count"),
+        "status.infra_failed.count",
+    )
+
+    canceled = status.get("canceled")
+    if not isinstance(canceled, dict) or "count" not in canceled:
+        raise ValueError("missing required field status.canceled.count")
+    canceled_count = _ensure_nonnegative_int(
+        canceled.get("count"),
+        "status.canceled.count",
+    )
+
+    total = passed + failed_tests
+    if non_test_failure_policy == "count-as-failure":
+        total += failed_infra + canceled_count
+
+    usage = results.get("usage")
+    if not isinstance(usage, dict):
+        raise ValueError("missing required object usage")
+    if "input_tokens" not in usage:
+        raise ValueError("missing required field usage.input_tokens")
+    if "output_tokens" not in usage:
+        raise ValueError("missing required field usage.output_tokens")
+    if "tool_calls" not in usage:
+        raise ValueError("missing required field usage.tool_calls")
+    input_tokens = _ensure_int(usage.get("input_tokens"), "usage.input_tokens")
+    output_tokens = _ensure_int(usage.get("output_tokens"), "usage.output_tokens")
+    tool_calls = _ensure_int(usage.get("tool_calls"), "usage.tool_calls")
+    cost_usd = _ensure_float_or_none(usage.get("cost_usd"), "usage.cost_usd")
+
+    runtime = results.get("runtime")
+    if not isinstance(runtime, dict):
+        raise ValueError("missing required object runtime")
+    if "run_ms" not in runtime:
+        raise ValueError("missing required field runtime.run_ms")
+    runtime_ms = _ensure_int(runtime.get("run_ms"), "runtime.run_ms")
+
+    status_total = passed + failed_tests + failed_infra + canceled_count
+    if total_instances != expected_instances:
+        raise NonReusableRunError(
+            f"total_instances must be {expected_instances}; found {total_instances}"
+        )
+    if status_total != total_instances:
+        raise NonReusableRunError(
+            f"status counts total {status_total}; expected {total_instances}"
+        )
+    if non_test_failure_policy == "reject" and (failed_infra or canceled_count):
+        raise NonReusableRunError(
+            "non-test failures are not allowed by the reject policy "
+            f"(infra_failed={failed_infra}, canceled={canceled_count})"
+        )
+    if total < minimum_valid_instances:
+        raise NonReusableRunError(
+            f"policy denominator is {total}; at least "
+            f"{minimum_valid_instances} valid instances are required"
+        )
+
+    return BenchmarkRun(
+        run_id=run_id_str,
+        timestamp=timestamp,
+        run_date=run_date,
+        total=total,
+        passed=passed,
+        status=status,
+        runtime_ms=runtime_ms,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        tool_calls=tool_calls,
+        cost_usd=cost_usd,
+        run_dir=results_json.parent,
+    )
+
+
+def _iter_run_results(base_dir: Path, recursive: bool) -> List[Path]:
+    if recursive:
+        return sorted(base_dir.glob("**/results.json"))
+
+    results: List[Path] = []
+    if not base_dir.exists():
+        return results
+
+    direct_results = base_dir / "results.json"
+    if direct_results.exists():
+        return [direct_results]
+
+    for item in sorted(base_dir.iterdir(), key=lambda p: p.name):
+        if item.is_dir():
+            candidate = item / "results.json"
+            if candidate.exists():
+                results.append(candidate)
+    return results
+
+
+def load_all_runs(
+    base_dir: Path,
+    *,
+    recursive: bool,
+    non_test_failure_policy: str,
+    expected_instances: int,
+    minimum_valid_instances: int,
+    required_results_json: Optional[Path] = None,
+) -> List[BenchmarkRun]:
+    runs: List[BenchmarkRun] = []
+    required_path = (
+        required_results_json.resolve()
+        if required_results_json is not None
+        else None
+    )
+    for results_json in _iter_run_results(base_dir, recursive):
+        try:
+            run = load_benchmark_run(
+                results_json,
+                non_test_failure_policy=non_test_failure_policy,
+                expected_instances=expected_instances,
+                minimum_valid_instances=minimum_valid_instances,
+            )
+        except (NonCompletedRunError, NonReusableRunError) as exc:
+            if required_path is not None and results_json.resolve() == required_path:
+                raise ValueError(
+                    f"required current run is not reusable: {exc}"
+                ) from exc
+            # Margin may persist a partial result before returning nonzero. It
+            # is useful for diagnosis but must never enter accuracy statistics.
+            # Likewise, a prior completed run that fails today's sample
+            # contract cannot be allowed to poison a retry.
+            continue
+        except ValueError as exc:
+            raise ValueError(f"{results_json}: {exc}") from exc
+        runs.append(run)
+
+    return sorted(runs, key=lambda run: (run.run_date, run.timestamp))
+
+
+def load_runs_from_directories(
+    base_dirs: List[Path],
+    *,
+    recursive: bool = False,
+    non_test_failure_policy: str,
+    expected_instances: int,
+    minimum_valid_instances: int,
+    required_results_json: Optional[Path] = None,
+) -> List[BenchmarkRun]:
+    runs: List[BenchmarkRun] = []
+    runs_by_id: Dict[str, Path] = {}
+    required_path = (
+        required_results_json.resolve()
+        if required_results_json is not None
+        else None
+    )
+    required_path_was_scanned = False
+
+    if required_results_json is not None and not required_results_json.is_file():
+        raise ValueError(
+            f"required current run results not found: {required_results_json}"
+        )
+
+    for base_dir in base_dirs:
+        if not base_dir.is_dir():
+            raise ValueError(f"runs directory not found: {base_dir}")
+
+        result_files = _iter_run_results(base_dir, recursive)
+        if not result_files:
+            raise ValueError(
+                f"no results.json files found in runs directory: {base_dir}"
+            )
+        if required_path is not None and any(
+            path.resolve() == required_path for path in result_files
+        ):
+            required_path_was_scanned = True
+
+        directory_runs = load_all_runs(
+            base_dir,
+            recursive=recursive,
+            non_test_failure_policy=non_test_failure_policy,
+            expected_instances=expected_instances,
+            minimum_valid_instances=minimum_valid_instances,
+            required_results_json=required_results_json,
+        )
+
+        for run in directory_runs:
+            previous_dir = runs_by_id.get(run.run_id)
+            if previous_dir is not None:
+                raise ValueError(
+                    f"duplicate run_id {run.run_id!r} found in {previous_dir} and {run.run_dir}"
+                )
+            runs_by_id[run.run_id] = run.run_dir
+            runs.append(run)
+
+    if required_path is not None and not required_path_was_scanned:
+        raise ValueError(
+            "required current run results are outside the configured runs "
+            f"directories: {required_results_json}"
+        )
+    if not runs:
+        raise ValueError(
+            "no completed results.json files found in configured runs directories"
+        )
+
+    return sorted(runs, key=lambda run: (run.run_date, run.timestamp))
+
+
+def aggregate_by_day(runs: List[BenchmarkRun]) -> Dict[date, DayStats]:
+    day_stats: Dict[date, DayStats] = {}
+    for run in runs:
+        day = day_stats.setdefault(run.run_date, DayStats(run_date=run.run_date))
+        day.total_trials += run.total
+        day.total_successes += run.passed
+        day.runs.append(run)
+    return day_stats
+
+
+def _log_factorial_binomial(n: int, k: int) -> float:
+    return math.lgamma(n + 1) - math.lgamma(k + 1) - math.lgamma(n - k + 1)
+
+
+def _log_binomial_pmf(n: int, k: int, p: float) -> float:
+    if k < 0 or k > n:
+        return float("-inf")
+    if p <= 0:
+        return 0.0 if k == 0 else float("-inf")
+    if p >= 1:
+        return 0.0 if k == n else float("-inf")
+
+    return _log_factorial_binomial(n, k) + (k * math.log(p)) + ((n - k) * math.log1p(-p))
+
+
+def _logsumexp(values: List[float]) -> float:
+    finite_values = [value for value in values if math.isfinite(value)]
+    if not finite_values:
+        return float("-inf")
+
+    max_value = max(finite_values)
+    total = sum(math.exp(value - max_value) for value in finite_values)
+    return max_value + math.log(total)
+
+
+def _binomial_cdf(n: int, k: int, p: float) -> float:
+    if k < 0:
+        return 0.0
+    if k >= n:
+        return 1.0
+    if p <= 0:
+        return 1.0 if k >= 0 else 0.0
+    if p >= 1:
+        return 0.0 if k < n else 1.0
+
+    log_cdf = _logsumexp([_log_binomial_pmf(n, i, p) for i in range(0, k + 1)])
+    return max(0.0, min(1.0, math.exp(log_cdf)))
+
+
+def _binomial_sf(n: int, k: int, p: float) -> float:
+    if k <= 0:
+        return 1.0
+    if k > n:
+        return 0.0
+    if p <= 0:
+        return 0.0
+    if p >= 1:
+        return 1.0
+
+    log_sf = _logsumexp([_log_binomial_pmf(n, i, p) for i in range(k, n + 1)])
+    return max(0.0, min(1.0, math.exp(log_sf)))
+
+
+def exact_binomial_test(k: int, n: int, p0: float, alternative: str) -> float:
+    if n == 0:
+        return 1.0
+
+    alternative = alternative.lower()
+    if alternative == "less":
+        return _binomial_cdf(n, k, p0)
+    if alternative == "greater":
+        return _binomial_sf(n, k, p0)
+    cdf = _binomial_cdf(n, k, p0)
+    sf = 1.0 - _binomial_cdf(n, k - 1, p0)
+    return min(1.0, 2.0 * min(cdf, sf))
+
+
+def wilson_confidence_interval(k: int, n: int, confidence: float = 0.95) -> Tuple[float, float]:
+    if n == 0:
+        return 0.0, 1.0
+
+    p_hat = k / n
+    z = 1.959963984540054
+    if confidence != 0.95:
+        # Conservative fallback for non-0.95 inputs.
+        from statistics import NormalDist
+
+        z = abs(NormalDist().inv_cdf((1 + confidence) / 2))
+
+    denominator = 1 + z**2 / n
+    center = (p_hat + z**2 / (2 * n)) / denominator
+    margin = z * math.sqrt(p_hat * (1 - p_hat) / n + z**2 / (4 * n**2)) / denominator
+
+    return max(0.0, center - margin), min(1.0, center + margin)
+
+
+def compute_significance_threshold(n: int, p0: float, alpha: float = 0.05) -> float:
+    if n == 0:
+        return 0.10
+
+    degradation_target = int(n * p0)
+    k_degrad = None
+    for k in range(degradation_target, -1, -1):
+        if exact_binomial_test(k, n, p0, "less") < alpha:
+            k_degrad = k
+            break
+
+    k_improv = None
+    for k in range(degradation_target + 1, n + 1):
+        if exact_binomial_test(k, n, p0, "greater") < alpha:
+            k_improv = k
+            break
+
+    delta_degrad = abs(p0 - (k_degrad / n)) if k_degrad is not None else 0.10
+    delta_improv = abs((k_improv / n) - p0) if k_improv is not None else 0.10
+    return min((delta_degrad + delta_improv) / 2, 0.15)
+
+
+def compute_window_stats(
+    day_stats: Dict[date, DayStats],
+    window_size: int,
+    target_date: date,
+    baseline_p0: float = BASELINE_P0,
+) -> Optional[WindowStats]:
+    successes = 0
+    trials = 0
+
+    for delta_days in range(window_size):
+        date_in_window = date.fromordinal(target_date.toordinal() - delta_days)
+        found = day_stats.get(date_in_window)
+        if found is not None:
+            successes += found.total_successes
+            trials += found.total_trials
+
+    if trials == 0:
+        return None
+
+    accuracy = successes / trials
+    delta = accuracy - baseline_p0
+    ci_lower, ci_upper = wilson_confidence_interval(successes, trials)
+    p_value_degradation = exact_binomial_test(successes, trials, baseline_p0, "less")
+    p_value_improvement = exact_binomial_test(successes, trials, baseline_p0, "greater")
+    significance_threshold = compute_significance_threshold(trials, baseline_p0)
+
+    return WindowStats(
+        window_size=window_size,
+        successes=successes,
+        trials=trials,
+        accuracy=accuracy,
+        delta=delta,
+        ci_lower=ci_lower,
+        ci_upper=ci_upper,
+        p_value_degradation=p_value_degradation,
+        p_value_improvement=p_value_improvement,
+        significance_threshold=significance_threshold,
+    )
+
+
+def compute_dashboard_stats(
+    runs: List[BenchmarkRun],
+    target_date: date,
+    baseline_p0: float = BASELINE_P0,
+) -> dict:
+    eligible_runs = [run for run in runs if run.run_date <= target_date]
+    day_stats = aggregate_by_day(eligible_runs)
+
+    timescales_output = {}
+    for name, window_size in TIMESCALES.items():
+        stats = compute_window_stats(day_stats, window_size, target_date, baseline_p0)
+        if stats:
+            timescales_output[name] = {
+                "window_size": stats.window_size,
+                "successes": stats.successes,
+                "trials": stats.trials,
+                "accuracy": round(stats.accuracy, 4),
+                "delta": round(stats.delta, 4),
+                "ci_lower": round(stats.ci_lower, 4),
+                "ci_upper": round(stats.ci_upper, 4),
+                "p_value_degradation": round(stats.p_value_degradation, 4),
+                "p_value_improvement": round(stats.p_value_improvement, 4),
+                "significance_threshold": round(stats.significance_threshold, 4),
+            }
+        else:
+            timescales_output[name] = None
+
+    sorted_dates = sorted(day_stats.keys(), reverse=True)[:30]
+    daily_history = []
+    for d in reversed(sorted_dates):
+        ds = day_stats[d]
+        daily_history.append(
+            {
+                "date": d.isoformat(),
+                "passed": ds.total_successes,
+                "total": ds.total_trials,
+                "accuracy": round(ds.accuracy, 4),
+            }
+        )
+
+    return {
+        "computed_at": datetime.now(UTC).replace(tzinfo=None).isoformat() + "Z",
+        "target_date": target_date.isoformat(),
+        "baseline_p0": baseline_p0,
+        "total_runs_analyzed": len(eligible_runs),
+        "timescales": timescales_output,
+        "daily_history": daily_history,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Compute statistics for margin daily runs using results.json files."
+    )
+    parser.add_argument(
+        "--runs_dir",
+        dest="runs_dirs",
+        type=Path,
+        action="append",
+        default=None,
+        help="Directory containing run outputs. Repeat to combine explicit model series (default: runs).",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        required=True,
+        help="Where to write the statistics JSON.",
+    )
+    parser.add_argument(
+        "--baseline",
+        type=float,
+        default=BASELINE_P0,
+        help=f"Baseline probability P0 for statistical tests (default: {BASELINE_P0})",
+    )
+    parser.add_argument(
+        "--recursive",
+        action="store_true",
+        help="Search results.json files recursively (includes nested model run folders).",
+    )
+    parser.add_argument(
+        "--date",
+        type=str,
+        default=None,
+        help="Target date for statistics in YYYY-MM-DD format (default: today).",
+    )
+    parser.add_argument(
+        "--non-test-failure-policy",
+        choices=NON_TEST_FAILURE_POLICIES,
+        required=True,
+        help=(
+            "How infra_failed and canceled instances affect accuracy: reject the "
+            "run, count them as failures, or exclude them. test_failed instances "
+            "always remain in the denominator."
+        ),
+    )
+    parser.add_argument(
+        "--expected-instances",
+        type=int,
+        required=True,
+        help="Required total_instances and status-count total for an eligible run.",
+    )
+    parser.add_argument(
+        "--minimum-valid-instances",
+        type=int,
+        required=True,
+        help="Minimum policy denominator for an eligible run.",
+    )
+    parser.add_argument(
+        "--required-results",
+        type=Path,
+        required=True,
+        help=(
+            "results.json for the current run. Unlike prior non-reusable runs, "
+            "this run must satisfy the aggregation contract."
+        ),
+    )
+    args = parser.parse_args()
+
+    if args.expected_instances <= 0:
+        raise SystemExit("--expected-instances must be positive")
+    if (
+        args.minimum_valid_instances <= 0
+        or args.minimum_valid_instances > args.expected_instances
+    ):
+        raise SystemExit(
+            "--minimum-valid-instances must be positive and no greater than "
+            "--expected-instances"
+        )
+
+    if args.date is None:
+        target_date = date.today()
+    else:
+        target_date = datetime.strptime(args.date, "%Y-%m-%d").date()
+
+    runs_dirs = args.runs_dirs or [Path("runs")]
+
+    try:
+        runs = load_runs_from_directories(
+            runs_dirs,
+            recursive=args.recursive,
+            non_test_failure_policy=args.non_test_failure_policy,
+            expected_instances=args.expected_instances,
+            minimum_valid_instances=args.minimum_valid_instances,
+            required_results_json=args.required_results,
+        )
+    except ValueError as exc:
+        raise SystemExit(f"Error: {exc}")
+
+    if not runs:
+        output = {
+            "computed_at": datetime.now(UTC).replace(tzinfo=None).isoformat() + "Z",
+            "target_date": target_date.isoformat(),
+            "baseline_p0": args.baseline,
+            "total_runs_analyzed": 0,
+            "timescales": {name: None for name in TIMESCALES},
+            "daily_history": [],
+        }
+    else:
+        output = compute_dashboard_stats(runs, target_date, baseline_p0=args.baseline)
+    output["non_test_failure_policy"] = args.non_test_failure_policy
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    with open(args.output, "w") as f:
+        json.dump(output, f, indent=2)
+
+    if output["timescales"].get("daily"):
+        daily = output["timescales"]["daily"]
+        print(f"\nDaily statistics ({target_date}):")
+        print(f"  Accuracy: {daily['accuracy']:.2%} ({daily['successes']}/{daily['trials']})")
+        print(f"  Delta from baseline: {daily['delta']:+.2%}")
+        print(f"  95% CI: [{daily['ci_lower']:.2%}, {daily['ci_upper']:.2%}]")
+        print(f"  p-value (degradation): {daily['p_value_degradation']:.4f}")
+        print(f"  p-value (improvement): {daily['p_value_improvement']:.4f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/ops/daily-runs/statistics/test_compute_stats.py
+++ b/ops/daily-runs/statistics/test_compute_stats.py
@@ -1,0 +1,458 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from datetime import date
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).with_name("compute_stats.py")
+SPEC = importlib.util.spec_from_file_location("daily_run_compute_stats", MODULE_PATH)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"Unable to load {MODULE_PATH}")
+STATS = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = STATS
+SPEC.loader.exec_module(STATS)
+
+
+def write_run(
+    series_dir: Path,
+    timestamp: str,
+    run_id: str,
+    *,
+    succeeded: int,
+    test_failed: int,
+    infra_failed: int = 0,
+    canceled: int = 0,
+    state: str = "completed",
+    total_instances: int | None = None,
+) -> None:
+    run_dir = series_dir / timestamp
+    run_dir.mkdir(parents=True)
+    total = succeeded + test_failed + infra_failed + canceled
+
+    def bucket(count: int) -> dict:
+        return {
+            "count": count,
+            "percentage": (count / total) * 100 if total else 0,
+        }
+
+    (run_dir / "results.json").write_text(
+        json.dumps(
+            {
+                "run_id": run_id,
+                "state": state,
+                "total_instances": (
+                    total if total_instances is None else total_instances
+                ),
+                "status": {
+                    "succeeded": bucket(succeeded),
+                    "test_failed": bucket(test_failed),
+                    "infra_failed": bucket(infra_failed),
+                    "canceled": bucket(canceled),
+                },
+                "usage": {
+                    "input_tokens": 100,
+                    "output_tokens": 20,
+                    "tool_calls": 5,
+                    "cost_usd": None,
+                },
+                "runtime": {"run_ms": 1_000},
+            }
+        )
+    )
+
+
+def load_runs(
+    base_dirs: list[Path],
+    *,
+    minimum_valid_instances: int = 1,
+    required_results_json: Path | None = None,
+) -> list:
+    return STATS.load_runs_from_directories(
+        base_dirs,
+        non_test_failure_policy="exclude",
+        expected_instances=50,
+        minimum_valid_instances=minimum_valid_instances,
+        required_results_json=required_results_json,
+    )
+
+
+class CombinedRunsTests(unittest.TestCase):
+    def test_failed_same_day_run_is_excluded_from_statistics(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            series = Path(temp_dir) / "series"
+            write_run(
+                series,
+                "20260712-040001",
+                "failed-partial",
+                succeeded=50,
+                test_failed=0,
+                state="failed",
+            )
+            write_run(
+                series,
+                "20260712-050001",
+                "completed",
+                succeeded=40,
+                test_failed=10,
+            )
+
+            runs = load_runs([series])
+            output = STATS.compute_dashboard_stats(
+                runs,
+                date(2026, 7, 12),
+                baseline_p0=0.8,
+            )
+
+            self.assertEqual([run.run_id for run in runs], ["completed"])
+            self.assertEqual(output["total_runs_analyzed"], 1)
+            self.assertEqual(output["timescales"]["daily"]["successes"], 40)
+            self.assertEqual(output["timescales"]["daily"]["trials"], 50)
+
+    def test_malformed_completed_same_day_run_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            series = Path(temp_dir) / "series"
+            write_run(
+                series,
+                "20260712-040001",
+                "valid",
+                succeeded=40,
+                test_failed=10,
+            )
+            write_run(
+                series,
+                "20260712-050001",
+                "malformed",
+                succeeded=40,
+                test_failed=10,
+            )
+            malformed_path = series / "20260712-050001" / "results.json"
+            malformed = json.loads(malformed_path.read_text())
+            del malformed["status"]["succeeded"]
+            malformed_path.write_text(json.dumps(malformed))
+
+            with self.assertRaisesRegex(
+                ValueError,
+                r"20260712-050001/results\.json: missing required field "
+                r"status\.succeeded\.count",
+            ):
+                load_runs([series])
+
+    def test_prior_completed_run_below_minimum_does_not_poison_retry(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            series = Path(temp_dir) / "series"
+            write_run(
+                series,
+                "20260712-040001",
+                "non-reusable-prior",
+                succeeded=49,
+                test_failed=0,
+                infra_failed=1,
+            )
+            write_run(
+                series,
+                "20260712-050001",
+                "valid-current",
+                succeeded=40,
+                test_failed=10,
+            )
+            current_results = series / "20260712-050001" / "results.json"
+
+            runs = load_runs(
+                [series],
+                minimum_valid_instances=50,
+                required_results_json=current_results,
+            )
+            output = STATS.compute_dashboard_stats(
+                runs,
+                date(2026, 7, 12),
+                baseline_p0=0.8,
+            )
+
+            self.assertEqual([run.run_id for run in runs], ["valid-current"])
+            self.assertEqual(output["total_runs_analyzed"], 1)
+            self.assertEqual(output["timescales"]["daily"]["successes"], 40)
+            self.assertEqual(output["timescales"]["daily"]["trials"], 50)
+
+    def test_prior_completed_runs_with_invalid_totals_are_excluded(self) -> None:
+        cases = (
+            {
+                "name": "reported total",
+                "succeeded": 40,
+                "test_failed": 10,
+                "total_instances": 49,
+            },
+            {
+                "name": "status total",
+                "succeeded": 40,
+                "test_failed": 9,
+                "total_instances": 50,
+            },
+        )
+        for case in cases:
+            with self.subTest(case["name"]), tempfile.TemporaryDirectory() as temp_dir:
+                series = Path(temp_dir) / "series"
+                write_run(
+                    series,
+                    "20260712-040001",
+                    "non-reusable-prior",
+                    succeeded=case["succeeded"],
+                    test_failed=case["test_failed"],
+                    total_instances=case["total_instances"],
+                )
+                write_run(
+                    series,
+                    "20260712-050001",
+                    "valid-current",
+                    succeeded=40,
+                    test_failed=10,
+                )
+                current_results = series / "20260712-050001" / "results.json"
+
+                runs = load_runs(
+                    [series],
+                    minimum_valid_instances=50,
+                    required_results_json=current_results,
+                )
+
+                self.assertEqual([run.run_id for run in runs], ["valid-current"])
+                self.assertEqual(sum(run.total for run in runs), 50)
+
+    def test_non_reusable_current_run_fails_instead_of_being_omitted(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            series = Path(temp_dir) / "series"
+            write_run(
+                series,
+                "20260712-040001",
+                "valid-prior",
+                succeeded=40,
+                test_failed=10,
+            )
+            write_run(
+                series,
+                "20260712-050001",
+                "invalid-current",
+                succeeded=49,
+                test_failed=0,
+                infra_failed=1,
+            )
+            current_results = series / "20260712-050001" / "results.json"
+
+            with self.assertRaisesRegex(
+                ValueError,
+                "required current run is not reusable: policy denominator is 49",
+            ):
+                load_runs(
+                    [series],
+                    minimum_valid_instances=50,
+                    required_results_json=current_results,
+                )
+
+    def test_non_test_failure_policy_is_explicit_and_deterministic(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            series = Path(temp_dir) / "series"
+            write_run(
+                series,
+                "20260712-040002",
+                "policy-test",
+                succeeded=38,
+                test_failed=10,
+                infra_failed=1,
+                canceled=1,
+            )
+            results_json = series / "20260712-040002" / "results.json"
+
+            excluded = STATS.load_benchmark_run(
+                results_json,
+                non_test_failure_policy="exclude",
+                expected_instances=50,
+                minimum_valid_instances=1,
+            )
+            counted = STATS.load_benchmark_run(
+                results_json,
+                non_test_failure_policy="count-as-failure",
+                expected_instances=50,
+                minimum_valid_instances=1,
+            )
+
+            self.assertEqual(excluded.total, 48)
+            self.assertEqual(counted.total, 50)
+            with self.assertRaisesRegex(ValueError, "reject policy"):
+                STATS.load_benchmark_run(
+                    results_json,
+                    non_test_failure_policy="reject",
+                    expected_instances=50,
+                    minimum_valid_instances=1,
+                )
+
+    def test_explicit_series_are_combined_and_future_runs_are_excluded(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            high = root / "gpt-5-6-sol-high"
+            xhigh = root / "gpt-5-6-sol-xhigh"
+            older = root / "gpt-5-5-xhigh"
+
+            write_run(
+                high,
+                "20260711-105627",
+                "high-0711",
+                succeeded=40,
+                test_failed=9,
+                infra_failed=1,
+            )
+            write_run(
+                xhigh,
+                "20260711-001500",
+                "xhigh-0711",
+                succeeded=39,
+                test_failed=7,
+                infra_failed=4,
+            )
+            write_run(
+                high,
+                "20260712-040002",
+                "high-0712",
+                succeeded=38,
+                test_failed=11,
+                infra_failed=1,
+            )
+            write_run(
+                high,
+                "20260713-040001",
+                "future-high",
+                succeeded=50,
+                test_failed=0,
+            )
+            write_run(
+                older,
+                "20260710-040001",
+                "older-model",
+                succeeded=1,
+                test_failed=49,
+            )
+
+            runs = load_runs([high, xhigh])
+            output = STATS.compute_dashboard_stats(runs, date(2026, 7, 12), baseline_p0=0.8340)
+
+            self.assertEqual(output["total_runs_analyzed"], 3)
+            self.assertEqual(
+                output["daily_history"],
+                [
+                    {"date": "2026-07-11", "passed": 79, "total": 95, "accuracy": 0.8316},
+                    {"date": "2026-07-12", "passed": 38, "total": 49, "accuracy": 0.7755},
+                ],
+            )
+            self.assertEqual(output["timescales"]["daily"]["successes"], 38)
+            self.assertEqual(output["timescales"]["daily"]["trials"], 49)
+            self.assertEqual(output["timescales"]["monthly"]["successes"], 117)
+            self.assertEqual(output["timescales"]["monthly"]["trials"], 144)
+            self.assertEqual(output["baseline_p0"], 0.8340)
+
+    def test_duplicate_run_ids_across_series_are_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            high = root / "gpt-5-6-sol-high"
+            xhigh = root / "gpt-5-6-sol-xhigh"
+
+            write_run(
+                high,
+                "20260711-105627",
+                "duplicate",
+                succeeded=40,
+                test_failed=10,
+            )
+            write_run(
+                xhigh,
+                "20260711-001500",
+                "duplicate",
+                succeeded=39,
+                test_failed=11,
+            )
+
+            with self.assertRaisesRegex(ValueError, "duplicate run_id"):
+                load_runs([high, xhigh])
+
+    def test_every_explicit_series_directory_must_exist_and_have_results(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            high = root / "gpt-5-6-sol-high"
+            empty_xhigh = root / "gpt-5-6-sol-xhigh"
+            empty_xhigh.mkdir()
+
+            write_run(
+                high,
+                "20260711-105627",
+                "high-0711",
+                succeeded=40,
+                test_failed=10,
+            )
+
+            with self.assertRaisesRegex(ValueError, "no results.json files"):
+                load_runs([high, empty_xhigh])
+
+            with self.assertRaisesRegex(ValueError, "runs directory not found"):
+                load_runs([high, root / "missing-series"])
+
+    def test_series_with_only_failed_runs_does_not_block_completed_series(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            high = root / "gpt-5-6-sol-high"
+            xhigh = root / "gpt-5-6-sol-xhigh"
+
+            write_run(
+                high,
+                "20260712-040001",
+                "completed-high",
+                succeeded=40,
+                test_failed=10,
+            )
+            write_run(
+                xhigh,
+                "20260712-050001",
+                "failed-xhigh",
+                succeeded=50,
+                test_failed=0,
+                state="failed",
+            )
+
+            runs = load_runs([high, xhigh])
+
+            self.assertEqual([run.run_id for run in runs], ["completed-high"])
+            self.assertEqual(sum(run.total for run in runs), 50)
+
+    def test_all_configured_series_with_only_failed_runs_are_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            high = root / "gpt-5-6-sol-high"
+            xhigh = root / "gpt-5-6-sol-xhigh"
+
+            write_run(
+                high,
+                "20260712-040001",
+                "failed-high",
+                succeeded=50,
+                test_failed=0,
+                state="failed",
+            )
+            write_run(
+                xhigh,
+                "20260712-050001",
+                "failed-xhigh",
+                succeeded=50,
+                test_failed=0,
+                state="failed",
+            )
+
+            with self.assertRaisesRegex(
+                ValueError,
+                "no completed results.json files found in configured runs directories",
+            ):
+                load_runs([high, xhigh])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ops/daily-runs/statistics/test_validate_reusable_run.py
+++ b/ops/daily-runs/statistics/test_validate_reusable_run.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).with_name("validate_reusable_run.py")
+SPEC = importlib.util.spec_from_file_location("validate_reusable_run", MODULE_PATH)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"Unable to load {MODULE_PATH}")
+VALIDATOR = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = VALIDATOR
+SPEC.loader.exec_module(VALIDATOR)
+
+
+class ReusableRunTests(unittest.TestCase):
+    def make_pair(
+        self,
+        root: Path,
+        *,
+        state: str = "completed",
+        instances: int = 50,
+        succeeded: int = 40,
+        test_failed: int = 10,
+        infra_failed: int = 0,
+        canceled: int = 0,
+        target_date: str = "2026-07-25",
+        policy: str | None = "exclude",
+    ) -> tuple[Path, Path]:
+        results_path = root / "results.json"
+        statistics_path = root / "statistics.json"
+        results_path.write_text(
+            json.dumps(
+                {
+                    "state": state,
+                    "total_instances": instances,
+                    "status": {
+                        "succeeded": {"count": succeeded},
+                        "test_failed": {"count": test_failed},
+                        "infra_failed": {"count": infra_failed},
+                        "canceled": {"count": canceled},
+                    },
+                }
+            )
+        )
+        statistics = {"target_date": target_date}
+        if policy is not None:
+            statistics["non_test_failure_policy"] = policy
+        statistics_path.write_text(json.dumps(statistics))
+        return results_path, statistics_path
+
+    def validate(self, results: Path, statistics: Path) -> None:
+        VALIDATOR.validate_reusable_run(
+            results,
+            statistics,
+            target_date="2026-07-25",
+            expected_instances=50,
+            minimum_valid_instances=50,
+            policy="exclude",
+        )
+
+    def test_complete_matching_pair_is_reusable(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            pair = self.make_pair(Path(temp_dir))
+            self.validate(*pair)
+
+    def test_failed_or_incomplete_results_are_not_reusable(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            pair = self.make_pair(Path(temp_dir), state="failed")
+            with self.assertRaisesRegex(ValueError, "state must be completed"):
+                self.validate(*pair)
+
+    def test_suite_size_date_and_policy_must_match(self) -> None:
+        cases = (
+            ({"instances": 49}, "total_instances"),
+            ({"target_date": "2026-07-24"}, "target_date"),
+            ({"policy": None}, "non_test_failure_policy"),
+            ({"policy": "count-as-failure"}, "non_test_failure_policy"),
+            (
+                {"succeeded": 39, "test_failed": 10, "infra_failed": 1},
+                "at least 50 valid instances",
+            ),
+        )
+        for values, message in cases:
+            with self.subTest(values=values):
+                with tempfile.TemporaryDirectory() as temp_dir:
+                    pair = self.make_pair(Path(temp_dir), **values)
+                    with self.assertRaisesRegex(ValueError, message):
+                        self.validate(*pair)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ops/daily-runs/statistics/validate_reusable_run.py
+++ b/ops/daily-runs/statistics/validate_reusable_run.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Validate whether a daily run is safe to reuse and sync."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+POLICIES = ("reject", "count-as-failure", "exclude")
+
+
+def _load_object(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"{path}: invalid JSON: {exc}") from exc
+    if not isinstance(value, dict):
+        raise ValueError(f"{path}: expected a JSON object")
+    return value
+
+
+def validate_reusable_run(
+    results_path: Path,
+    statistics_path: Path,
+    *,
+    target_date: str,
+    expected_instances: int,
+    minimum_valid_instances: int,
+    policy: str,
+) -> None:
+    results = _load_object(results_path)
+    statistics = _load_object(statistics_path)
+
+    if results.get("state") != "completed":
+        raise ValueError(
+            f"{results_path}: state must be completed; found {results.get('state')!r}"
+        )
+    if results.get("total_instances") != expected_instances:
+        raise ValueError(
+            f"{results_path}: total_instances must be {expected_instances}; "
+            f"found {results.get('total_instances')!r}"
+        )
+    status = results.get("status")
+    if not isinstance(status, dict):
+        raise ValueError(f"{results_path}: status must be an object")
+    counts: dict[str, int] = {}
+    for name in ("succeeded", "test_failed", "infra_failed", "canceled"):
+        bucket = status.get(name)
+        count = bucket.get("count") if isinstance(bucket, dict) else None
+        if not isinstance(count, int) or isinstance(count, bool) or count < 0:
+            raise ValueError(
+                f"{results_path}: status.{name}.count must be a non-negative integer"
+            )
+        counts[name] = count
+    if sum(counts.values()) != expected_instances:
+        raise ValueError(
+            f"{results_path}: status counts must total {expected_instances}"
+        )
+    if policy == "reject" and (counts["infra_failed"] or counts["canceled"]):
+        raise ValueError(
+            f"{results_path}: reject policy does not allow infra_failed or canceled"
+        )
+    valid_instances = counts["succeeded"] + counts["test_failed"]
+    denominator = (
+        valid_instances
+        if policy == "exclude"
+        else valid_instances + counts["infra_failed"] + counts["canceled"]
+    )
+    if denominator < minimum_valid_instances:
+        raise ValueError(
+            f"{results_path}: policy denominator is {denominator}; "
+            f"at least {minimum_valid_instances} valid instances are required"
+        )
+    if statistics.get("target_date") != target_date:
+        raise ValueError(
+            f"{statistics_path}: target_date must be {target_date}; "
+            f"found {statistics.get('target_date')!r}"
+        )
+    if statistics.get("non_test_failure_policy") != policy:
+        raise ValueError(
+            f"{statistics_path}: non_test_failure_policy must be {policy}; "
+            f"found {statistics.get('non_test_failure_policy')!r}"
+        )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Validate a paired daily result/statistics run before reuse."
+    )
+    parser.add_argument("--results", type=Path, required=True)
+    parser.add_argument("--statistics", type=Path, required=True)
+    parser.add_argument("--target-date", required=True)
+    parser.add_argument("--expected-instances", type=int, required=True)
+    parser.add_argument("--minimum-valid-instances", type=int, required=True)
+    parser.add_argument("--policy", choices=POLICIES, required=True)
+    args = parser.parse_args()
+
+    if args.expected_instances <= 0:
+        raise SystemExit("--expected-instances must be positive")
+    if (
+        args.minimum_valid_instances <= 0
+        or args.minimum_valid_instances > args.expected_instances
+    ):
+        raise SystemExit(
+            "--minimum-valid-instances must be positive and no greater than "
+            "--expected-instances"
+        )
+    try:
+        validate_reusable_run(
+            args.results,
+            args.statistics,
+            target_date=args.target_date,
+            expected_instances=args.expected_instances,
+            minimum_valid_instances=args.minimum_valid_instances,
+            policy=args.policy,
+        )
+    except ValueError as exc:
+        raise SystemExit(f"Not reusable: {exc}") from exc
+
+
+if __name__ == "__main__":
+    main()

--- a/ops/daily-runs/sync-run.sh
+++ b/ops/daily-runs/sync-run.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 --source-run <run-dir> --destination-root <tracker-data-dir>" >&2
+}
+
+SOURCE_RUN=""
+DESTINATION_ROOT=""
+while (($# > 0)); do
+  case "$1" in
+    --source-run)
+      SOURCE_RUN="${2:-}"
+      shift 2
+      ;;
+    --destination-root)
+      DESTINATION_ROOT="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+if [ -z "${SOURCE_RUN}" ] || [ -z "${DESTINATION_ROOT}" ]; then
+  usage
+  exit 2
+fi
+
+run_name="${SOURCE_RUN##*/}"
+if ! [[ "${run_name}" =~ ^[0-9]{8}-[0-9]{6}$ ]]; then
+  echo "Source run directory must end in YYYYMMDD-HHMMSS: ${SOURCE_RUN}" >&2
+  exit 2
+fi
+for filename in results.json statistics.json; do
+  if [ ! -f "${SOURCE_RUN}/${filename}" ]; then
+    echo "Completed source run is missing ${filename}: ${SOURCE_RUN}" >&2
+    exit 1
+  fi
+done
+
+destination_run="${DESTINATION_ROOT}/${run_name//-/_}"
+mkdir -p "${destination_run}"
+rsync -a \
+  --include='results.json' \
+  --include='statistics.json' \
+  --exclude='*' \
+  "${SOURCE_RUN}/" "${destination_run}/"
+
+for filename in results.json statistics.json; do
+  cmp -s "${SOURCE_RUN}/${filename}" "${destination_run}/${filename}" || {
+    echo "Synced ${filename} does not match its source: ${destination_run}" >&2
+    exit 1
+  }
+done

--- a/ops/daily-runs/test.sh
+++ b/ops/daily-runs/test.sh
@@ -9,6 +9,7 @@ bash -n \
   "${SCRIPT_DIR}/run-codex.sh" \
   "${SCRIPT_DIR}/run-claude-code.sh" \
   "${SCRIPT_DIR}/sync-run.sh" \
+  "${SCRIPT_DIR}/tests/publication-mode.sh" \
   "${SCRIPT_DIR}/tests/retry-safe.sh" \
   "${SCRIPT_DIR}/lib/paths.sh"
 
@@ -23,6 +24,7 @@ PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover \
   -s "${SCRIPT_DIR}/statistics" \
   -p 'test_*.py'
 "${SCRIPT_DIR}/tests/retry-safe.sh"
+"${SCRIPT_DIR}/tests/publication-mode.sh"
 "${SCRIPT_DIR}/run.sh" --help
 "${SCRIPT_DIR}/run-from-cron.sh" --help
 "${SCRIPT_DIR}/sync-run.sh" --help

--- a/ops/daily-runs/test.sh
+++ b/ops/daily-runs/test.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+bash -n \
+  "${SCRIPT_DIR}/run.sh" \
+  "${SCRIPT_DIR}/run-from-cron.sh" \
+  "${SCRIPT_DIR}/run-codex.sh" \
+  "${SCRIPT_DIR}/run-claude-code.sh" \
+  "${SCRIPT_DIR}/sync-run.sh" \
+  "${SCRIPT_DIR}/tests/retry-safe.sh" \
+  "${SCRIPT_DIR}/lib/paths.sh"
+
+source "${SCRIPT_DIR}/lib/paths.sh"
+expected_default_root="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+test "$(marginlab_eval_workspace_root "${SCRIPT_DIR}")" = "${expected_default_root}"
+test "$(
+  MARGINLAB_EVAL_WORKSPACE_ROOT="${SCRIPT_DIR}" \
+    marginlab_eval_workspace_root "${SCRIPT_DIR}"
+)" = "${SCRIPT_DIR}"
+PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover \
+  -s "${SCRIPT_DIR}/statistics" \
+  -p 'test_*.py'
+"${SCRIPT_DIR}/tests/retry-safe.sh"
+"${SCRIPT_DIR}/run.sh" --help
+"${SCRIPT_DIR}/run-from-cron.sh" --help
+"${SCRIPT_DIR}/sync-run.sh" --help

--- a/ops/daily-runs/tests/publication-mode.sh
+++ b/ops/daily-runs/tests/publication-mode.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FIXTURE_ROOT="$(mktemp -d /tmp/marginlab-daily-publication-test.XXXXXX)"
+trap 'rm -rf -- "${FIXTURE_ROOT}"' EXIT
+
+WORKSPACE_ROOT="${FIXTURE_ROOT}/workspace"
+STATE_ROOT="${FIXTURE_ROOT}/state"
+RAW_ROOT="${FIXTURE_ROOT}/raw"
+AUTOMATION_ROOT="${FIXTURE_ROOT}/automation"
+EVALUATION_ROOT="${FIXTURE_ROOT}/evals"
+BIN_ROOT="${FIXTURE_ROOT}/bin"
+PUBLISH_LOG="${FIXTURE_ROOT}/publish.log"
+MARGIN_LOG="${FIXTURE_ROOT}/margin.log"
+WARMUP_LOG="${FIXTURE_ROOT}/warmup.log"
+TARGET_TIMESTAMP="20260725-080000"
+TEST_COMMIT="1111111111111111111111111111111111111111"
+
+mkdir -p \
+  "${WORKSPACE_ROOT}/swe-suites" \
+  "${STATE_ROOT}/runs/codex/gpt-5-6-sol-high/20260725-040001" \
+  "${STATE_ROOT}/runs/claude-code/20260725-045635" \
+  "${RAW_ROOT}" \
+  "${AUTOMATION_ROOT}/hosting" \
+  "${EVALUATION_ROOT}" \
+  "${BIN_ROOT}"
+
+for run_root in \
+  "${STATE_ROOT}/runs/codex/gpt-5-6-sol-high/20260725-040001" \
+  "${STATE_ROOT}/runs/claude-code/20260725-045635"; do
+  printf '{"state":"completed","total_instances":50,"status":{"succeeded":{"count":40},"test_failed":{"count":10},"infra_failed":{"count":0},"canceled":{"count":0}}}\n' \
+    >"${run_root}/results.json"
+  printf '{"target_date":"2026-07-25","non_test_failure_policy":"exclude"}\n' \
+    >"${run_root}/statistics.json"
+done
+
+cat >"${BIN_ROOT}/margin" <<'MARGIN'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'unexpected margin invocation\n' >>"${MARGIN_LOG}"
+exit 99
+MARGIN
+chmod +x "${BIN_ROOT}/margin"
+
+cat >"${STATE_ROOT}/warmup-claude.sh" <<'WARMUP'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'unexpected warmup invocation\n' >>"${WARMUP_LOG}"
+WARMUP
+chmod +x "${STATE_ROOT}/warmup-claude.sh"
+
+cat >"${BIN_ROOT}/git" <<'GIT'
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "$#" -eq 4 ] \
+  && [ "$1" = "-C" ] \
+  && [ "$3" = "rev-parse" ] \
+  && [ "$4" = "HEAD" ]; then
+  printf '%s\n' "${TEST_COMMIT}"
+  exit 0
+fi
+printf 'unexpected git invocation:' >&2
+printf ' %q' "$@" >&2
+printf '\n' >&2
+exit 99
+GIT
+chmod +x "${BIN_ROOT}/git"
+
+cat >"${BIN_ROOT}/npm" <<'NPM'
+#!/usr/bin/env bash
+set -euo pipefail
+{
+  printf 'confirmation=%s\n' "${MARGINLAB_SITE_DATA_PUBLISH:-}"
+  printf 'arg=%s\n' "$@"
+} >>"${PUBLISH_LOG}"
+NPM
+chmod +x "${BIN_ROOT}/npm"
+
+COMMON_ENV=(
+  env
+  "PATH=${BIN_ROOT}:${PATH}"
+  "TEST_COMMIT=${TEST_COMMIT}"
+  "PUBLISH_LOG=${PUBLISH_LOG}"
+  "MARGINLAB_DAILY_RUN_TIMESTAMP=${TARGET_TIMESTAMP}"
+  "MARGINLAB_EVAL_WORKSPACE_ROOT=${WORKSPACE_ROOT}"
+  "MARGINLAB_DAILY_STATE_DIR=${STATE_ROOT}"
+  "MARGINLAB_RAW_REPOSITORY=${RAW_ROOT}"
+  "MARGINLAB_AUTOMATION_ROOT=${AUTOMATION_ROOT}"
+  "MARGINLAB_EVALUATION_ROOT=${EVALUATION_ROOT}"
+  "MARGINLAB_DAILY_LOCK_FILE=${FIXTURE_ROOT}/daily.lock"
+  "MARGINLAB_SITE_DATA_PUBLISH=1"
+  "MARGIN_LOG=${MARGIN_LOG}"
+  "WARMUP_LOG=${WARMUP_LOG}"
+)
+
+# Default mode reaches the publisher only after tracker validation and strips
+# even an inherited write-confirmation variable. It cannot commit or push.
+"${COMMON_ENV[@]}" "${SCRIPT_DIR}/run.sh"
+test "$(grep -Fc 'confirmation=' "${PUBLISH_LOG}")" -eq 1
+grep -Fx 'confirmation=' "${PUBLISH_LOG}"
+if grep -Fxq 'arg=--publish' "${PUBLISH_LOG}"; then
+  echo "Dry run unexpectedly supplied --publish" >&2
+  exit 1
+fi
+grep -Fx 'arg=publish:site-data' "${PUBLISH_LOG}"
+grep -Fx 'arg=--target-date' "${PUBLISH_LOG}"
+grep -Fx 'arg=2026-07-25' "${PUBLISH_LOG}"
+
+# Explicit publication supplies both independent confirmations. The
+# site-data publisher owns the validated site-data-only commit and leased
+# direct push to main.
+: >"${PUBLISH_LOG}"
+"${COMMON_ENV[@]}" "${SCRIPT_DIR}/run.sh" --publish
+test "$(grep -Fc 'confirmation=' "${PUBLISH_LOG}")" -eq 1
+grep -Fx 'confirmation=1' "${PUBLISH_LOG}"
+grep -Fx 'arg=--publish' "${PUBLISH_LOG}"
+grep -Fx 'arg=--expected-instances' "${PUBLISH_LOG}"
+grep -Fx 'arg=--minimum-valid-instances' "${PUBLISH_LOG}"
+grep -Fx 'arg=--non-test-failure-policy' "${PUBLISH_LOG}"
+
+test ! -e "${MARGIN_LOG}"
+test ! -e "${WARMUP_LOG}"
+
+# The pre-activation name was misleading: this command publishes data to Git
+# and never directly deploys Firebase.
+if "${COMMON_ENV[@]}" "${SCRIPT_DIR}/run.sh" --deploy; then
+  echo "Expected deprecated --deploy mode to be rejected" >&2
+  exit 1
+fi

--- a/ops/daily-runs/tests/retry-safe.sh
+++ b/ops/daily-runs/tests/retry-safe.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FIXTURE_ROOT="$(mktemp -d /tmp/marginlab-daily-retry-test.XXXXXX)"
+trap 'rm -rf -- "${FIXTURE_ROOT}"' EXIT
+
+WORKSPACE_ROOT="${FIXTURE_ROOT}/workspace"
+STATE_ROOT="${FIXTURE_ROOT}/state"
+RAW_ROOT="${FIXTURE_ROOT}/raw"
+BIN_ROOT="${FIXTURE_ROOT}/bin"
+MARGIN_LOG="${FIXTURE_ROOT}/margin.log"
+WARMUP_LOG="${FIXTURE_ROOT}/warmup.log"
+TARGET_TIMESTAMP="20260725-080000"
+
+mkdir -p \
+  "${WORKSPACE_ROOT}/swe-suites" \
+  "${STATE_ROOT}/runs/codex/gpt-5-6-sol-high/20260725-040001" \
+  "${STATE_ROOT}/runs/claude-code/20260725-045635" \
+  "${RAW_ROOT}/data/benchmarks/degradation_trackers/codex/swe-bench-pro/data/20260725_040001" \
+  "${RAW_ROOT}/data/benchmarks/degradation_trackers/claude_code/swe-bench-pro/data/20260725_045635" \
+  "${BIN_ROOT}"
+
+for run_root in \
+  "${STATE_ROOT}/runs/codex/gpt-5-6-sol-high/20260725-040001" \
+  "${STATE_ROOT}/runs/claude-code/20260725-045635"; do
+  printf '{"state":"completed","total_instances":50,"status":{"succeeded":{"count":40},"test_failed":{"count":10},"infra_failed":{"count":0},"canceled":{"count":0}}}\n' \
+    >"${run_root}/results.json"
+  printf '{"target_date":"2026-07-25","non_test_failure_policy":"exclude"}\n' \
+    >"${run_root}/statistics.json"
+done
+
+# Model an interrupted prior sync: results exists in each raw destination but
+# statistics is absent and the results content is incomplete.
+printf 'partial\n' \
+  >"${RAW_ROOT}/data/benchmarks/degradation_trackers/codex/swe-bench-pro/data/20260725_040001/results.json"
+printf 'partial\n' \
+  >"${RAW_ROOT}/data/benchmarks/degradation_trackers/claude_code/swe-bench-pro/data/20260725_045635/results.json"
+
+cat >"${BIN_ROOT}/margin" <<'MARGIN'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'unexpected margin invocation\n' >>"${MARGIN_LOG}"
+exit 99
+MARGIN
+chmod +x "${BIN_ROOT}/margin"
+
+cat >"${STATE_ROOT}/warmup-claude.sh" <<'WARMUP'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'unexpected warmup invocation\n' >>"${WARMUP_LOG}"
+WARMUP
+chmod +x "${STATE_ROOT}/warmup-claude.sh"
+
+COMMON_ENV=(
+  env
+  "PATH=${BIN_ROOT}:${PATH}"
+  "RUN_TIMESTAMP=${TARGET_TIMESTAMP}"
+  "MARGINLAB_EVAL_WORKSPACE_ROOT=${WORKSPACE_ROOT}"
+  "MARGINLAB_DAILY_STATE_DIR=${STATE_ROOT}"
+  "MARGINLAB_RAW_REPOSITORY=${RAW_ROOT}"
+  "MARGIN_LOG=${MARGIN_LOG}"
+  "WARMUP_LOG=${WARMUP_LOG}"
+)
+
+"${COMMON_ENV[@]}" "${SCRIPT_DIR}/run-codex.sh"
+"${COMMON_ENV[@]}" "${SCRIPT_DIR}/run-claude-code.sh"
+# A second retry is an idempotent sync, not another paid evaluation.
+"${COMMON_ENV[@]}" "${SCRIPT_DIR}/run-codex.sh"
+"${COMMON_ENV[@]}" "${SCRIPT_DIR}/run-claude-code.sh"
+
+cmp -s \
+  "${STATE_ROOT}/runs/codex/gpt-5-6-sol-high/20260725-040001/results.json" \
+  "${RAW_ROOT}/data/benchmarks/degradation_trackers/codex/swe-bench-pro/data/20260725_040001/results.json"
+cmp -s \
+  "${STATE_ROOT}/runs/codex/gpt-5-6-sol-high/20260725-040001/statistics.json" \
+  "${RAW_ROOT}/data/benchmarks/degradation_trackers/codex/swe-bench-pro/data/20260725_040001/statistics.json"
+cmp -s \
+  "${STATE_ROOT}/runs/claude-code/20260725-045635/results.json" \
+  "${RAW_ROOT}/data/benchmarks/degradation_trackers/claude_code/swe-bench-pro/data/20260725_045635/results.json"
+cmp -s \
+  "${STATE_ROOT}/runs/claude-code/20260725-045635/statistics.json" \
+  "${RAW_ROOT}/data/benchmarks/degradation_trackers/claude_code/swe-bench-pro/data/20260725_045635/statistics.json"
+test ! -e "${MARGIN_LOG}"
+test ! -e "${WARMUP_LOG}"
+
+# More than one completed run for the target day is ambiguous and must not
+# sync or start a new evaluation.
+second_codex="${STATE_ROOT}/runs/codex/gpt-5-6-sol-high/20260725-050001"
+mkdir -p "${second_codex}"
+printf '{"state":"completed","total_instances":50,"status":{"succeeded":{"count":40},"test_failed":{"count":10},"infra_failed":{"count":0},"canceled":{"count":0}}}\n' \
+  >"${second_codex}/results.json"
+printf '{"target_date":"2026-07-25","non_test_failure_policy":"exclude"}\n' \
+  >"${second_codex}/statistics.json"
+
+if "${COMMON_ENV[@]}" "${SCRIPT_DIR}/run-codex.sh"; then
+  echo "Expected duplicate completed Codex runs to fail" >&2
+  exit 1
+fi
+test ! -e "${MARGIN_LOG}"


### PR DESCRIPTION
## Summary

- validate documentation structure and links on every relevant change
- dispatch immutable docs revisions to the MarginLab website for previews and releases
- replace GitBook links in the repository with `marginlab.ai/docs` links
- version the Codex and Claude Code daily-run orchestration and statistics code
- make daily retries resumable and require complete, policy-consistent 50-instance results before publication
- replace the misleading `--deploy` mode with an explicit, dual-gated `--publish` mode

## Why

Documentation was coupled to GitBook, while the daily website update depended on unversioned machine-local scripts and direct Firebase deployment. This change makes both inputs reviewable and reproducible without activating production.

## Impact

After the companion website PR is merged and GitHub App credentials are configured, docs changes can trigger an immutable website build.

The daily runner always invokes the website publisher after both trackers pass. Default mode strips any inherited publication confirmation and performs only an export/validation dry run. Explicit `--publish` mode supplies both independent gates and asks the website publisher to create one validated `site-data/**`-only commit directly on current website `main`. It does not open a pull request, auto-merge anything, or deploy Firebase.

The installed 4 a.m. cron continues to call the old external runner; this PR does not change cron, publish site data, spend evaluation tokens, or deploy Firebase.

## Validation

- validated 9 documentation pages and 9 navigation entries
- 2 docs-dispatch tests pass
- 14 daily-run/statistics tests plus retry-safe and publication-mode shell integrations pass
- website publisher suite passes 22 tests, including remote races, ambiguous push recovery, path scoping, and `--no-follow-tags`
- all workflow files pass `actionlint` 1.7.12
- dedicated website automation clone is clean on `main`, has canonical fetch/push URLs, carries the opt-in marker, and passes `git push --dry-run`

## Activation

The checked-in runbook requires a post-merge fast-forward and an atomic cron switch to the versioned runner **without** `--publish`. Only after a scheduled dry run succeeds and the website checks are ready does a second atomic crontab edit add `--publish`.

The July 25 local statistics predate the new explicit `non_test_failure_policy` field, so the first operational rehearsal should use a fresh scheduled date or reconcile that legacy state deliberately.
